### PR TITLE
Add অনুশীলন practice section with three N5 lesson games

### DIFF
--- a/lib/screens/course_list_screen.dart
+++ b/lib/screens/course_list_screen.dart
@@ -11,7 +11,10 @@ import 'package:ez_trainz/models/program.dart';
 import 'package:ez_trainz/screens/hiragana_lesson1_screen.dart';
 import 'package:ez_trainz/screens/lesson_screen.dart';
 import 'package:ez_trainz/screens/login_screen.dart';
+import 'package:ez_trainz/screens/n5_hero_number1_lesson_screen.dart';
+import 'package:ez_trainz/screens/n5_hi_hello_lesson_screen.dart';
 import 'package:ez_trainz/screens/n5_kana_modules_screen.dart';
+import 'package:ez_trainz/screens/n5_weekdays_lesson_screen.dart';
 
 class CourseListScreen extends StatefulWidget {
   const CourseListScreen({super.key});
@@ -304,8 +307,11 @@ class _CourseListScreenState extends State<CourseListScreen> {
                       24,
                       isJlc ? 20 : 16,
                     ),
-                    itemCount: ctrl.courses.length,
+                    itemCount: ctrl.courses.length + (isJlc ? 1 : 0),
                     itemBuilder: (_, i) {
+                      if (isJlc && i == ctrl.courses.length) {
+                        return const _AnushilanCard();
+                      }
                       final course = ctrl.courses[i];
                       return _ExpandableCourseCard(
                         course: course,
@@ -823,6 +829,298 @@ class _LessonListTile extends StatelessWidget {
               ),
             ],
           ),
+        ),
+      ),
+    );
+  }
+}
+
+// ── অনুশীলন card (JLC-only static card with lessons) ───────────────
+class _AnushilanCard extends StatefulWidget {
+  const _AnushilanCard();
+
+  @override
+  State<_AnushilanCard> createState() => _AnushilanCardState();
+}
+
+class _AnushilanCardState extends State<_AnushilanCard> {
+  bool _expanded = false;
+
+  static const _badgeColor = Color(0xFFFF8C00);
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      margin: const EdgeInsets.only(bottom: 16),
+      decoration: BoxDecoration(
+        color: Colors.white,
+        borderRadius: BorderRadius.circular(16),
+        border: Border.all(color: const Color(0xFFE2E8F0)),
+        boxShadow: [
+          BoxShadow(
+            color: const Color(0xFF0F172A).withValues(alpha: 0.08),
+            blurRadius: 16,
+            offset: const Offset(0, 4),
+          ),
+        ],
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          Material(
+            color: Colors.transparent,
+            child: InkWell(
+              onTap: () => setState(() => _expanded = !_expanded),
+              borderRadius: BorderRadius.vertical(
+                top: const Radius.circular(15),
+                bottom: _expanded ? Radius.zero : const Radius.circular(15),
+              ),
+              child: Padding(
+                padding: const EdgeInsets.all(20),
+                child: Row(
+                  children: [
+                    Container(
+                      width: 52,
+                      height: 52,
+                      decoration: BoxDecoration(
+                        color: _badgeColor.withValues(alpha: 0.15),
+                        borderRadius: BorderRadius.circular(14),
+                      ),
+                      child: const Center(
+                        child: Text(
+                          '✏️',
+                          style: TextStyle(fontSize: 22),
+                        ),
+                      ),
+                    ),
+                    const SizedBox(width: 16),
+                    Expanded(
+                      child: Column(
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        children: [
+                          const Text(
+                            'অনুশীলন',
+                            style: TextStyle(
+                              color: Color(0xFF0F172A),
+                              fontSize: 17,
+                              fontWeight: FontWeight.w700,
+                            ),
+                          ),
+                          const SizedBox(height: 4),
+                          const Text(
+                            'অনুশীলন করুন ও দক্ষতা বাড়ান',
+                            style: TextStyle(
+                              color: Color(0xFF64748B),
+                              fontSize: 13,
+                            ),
+                            maxLines: 2,
+                            overflow: TextOverflow.ellipsis,
+                          ),
+                          const SizedBox(height: 8),
+                          const Text(
+                            '৩টি পাঠ',
+                            style: TextStyle(
+                              color: _badgeColor,
+                              fontSize: 12,
+                              fontWeight: FontWeight.w600,
+                            ),
+                          ),
+                        ],
+                      ),
+                    ),
+                    AnimatedRotation(
+                      turns: _expanded ? 0.5 : 0,
+                      duration: const Duration(milliseconds: 220),
+                      curve: Curves.easeInOut,
+                      child: const Icon(
+                        Icons.expand_more_rounded,
+                        color: Color(0xFF64748B),
+                        size: 28,
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+            ),
+          ),
+          AnimatedSize(
+            duration: const Duration(milliseconds: 260),
+            curve: Curves.easeInOut,
+            alignment: Alignment.topCenter,
+            child: _expanded
+                ? Container(
+                    width: double.infinity,
+                    decoration: const BoxDecoration(
+                      color: Color(0xFFF1F5F9),
+                      border: Border(
+                        top: BorderSide(color: Color(0xFFE2E8F0)),
+                      ),
+                      borderRadius: BorderRadius.vertical(
+                        bottom: Radius.circular(15),
+                      ),
+                    ),
+                    padding: const EdgeInsets.fromLTRB(12, 14, 12, 14),
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        const Text(
+                          'পাঠসমূহ',
+                          style: TextStyle(
+                            color: Color(0xFF64748B),
+                            fontSize: 12,
+                            fontWeight: FontWeight.w700,
+                            letterSpacing: 1.1,
+                          ),
+                        ),
+                        const SizedBox(height: 10),
+                        _PracticeLessonCard(
+                          number: '１',
+                          title: 'পাঠ ১ঃ হিরো নাম্বার ১',
+                          subtitle: 'জাপানি সংখ্যা • হিরাগানা • গেম',
+                          gradient: const [Color(0xFFFF8C00), Color(0xFFFF5722)],
+                          glow: const Color(0xFFFF8C00),
+                          onTap: () => Get.to(
+                            () => const N5HeroNumber1LessonScreen(),
+                            transition: Transition.rightToLeftWithFade,
+                            duration: const Duration(milliseconds: 300),
+                          ),
+                        ),
+                        const SizedBox(height: 10),
+                        _PracticeLessonCard(
+                          number: '２',
+                          title: 'পাঠ ২ঃ জাপানিজে হাই-হ্যালো',
+                          subtitle: 'অভিবাদন • শুভেচ্ছা • কথোপকথন',
+                          gradient: const [Color(0xFF06B6D4), Color(0xFF0891B2)],
+                          glow: const Color(0xFF06B6D4),
+                          onTap: () => Get.to(
+                            () => const N5HiHelloLessonScreen(),
+                            transition: Transition.rightToLeftWithFade,
+                            duration: const Duration(milliseconds: 300),
+                          ),
+                        ),
+                        const SizedBox(height: 10),
+                        _PracticeLessonCard(
+                          number: '３',
+                          title: 'পাঠ ৩ঃ শুক্র-শনি বাকিটা জানি',
+                          subtitle: 'সপ্তাহের দিন • ক্যালেন্ডার • অভ্যাস',
+                          gradient: const [Color(0xFF8B5CF6), Color(0xFF6D28D9)],
+                          glow: const Color(0xFF8B5CF6),
+                          onTap: () => Get.to(
+                            () => const N5WeekdaysLessonScreen(),
+                            transition: Transition.rightToLeftWithFade,
+                            duration: const Duration(milliseconds: 300),
+                          ),
+                        ),
+                      ],
+                    ),
+                  )
+                : const SizedBox(width: double.infinity),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+// ── Reusable lesson card used inside অনুশীলন ─────────────────────────
+class _PracticeLessonCard extends StatelessWidget {
+  const _PracticeLessonCard({
+    required this.number,
+    required this.title,
+    required this.subtitle,
+    required this.gradient,
+    required this.glow,
+    required this.onTap,
+  });
+
+  final String number;
+  final String title;
+  final String subtitle;
+  final List<Color> gradient;
+  final Color glow;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    return GestureDetector(
+      onTap: onTap,
+      child: Container(
+        width: double.infinity,
+        padding: const EdgeInsets.all(14),
+        decoration: BoxDecoration(
+          gradient: LinearGradient(
+            colors: gradient,
+            begin: Alignment.topLeft,
+            end: Alignment.bottomRight,
+          ),
+          borderRadius: BorderRadius.circular(14),
+          boxShadow: [
+            BoxShadow(
+              color: glow.withValues(alpha: 0.28),
+              blurRadius: 10,
+              offset: const Offset(0, 3),
+            ),
+          ],
+        ),
+        child: Row(
+          children: [
+            Container(
+              width: 44,
+              height: 44,
+              decoration: BoxDecoration(
+                color: Colors.white.withValues(alpha: 0.2),
+                borderRadius: BorderRadius.circular(12),
+              ),
+              child: Center(
+                child: Text(
+                  number,
+                  style: const TextStyle(
+                    color: Colors.white,
+                    fontSize: 22,
+                    fontWeight: FontWeight.w900,
+                  ),
+                ),
+              ),
+            ),
+            const SizedBox(width: 12),
+            Expanded(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(
+                    title,
+                    style: const TextStyle(
+                      color: Colors.white,
+                      fontSize: 15,
+                      fontWeight: FontWeight.w800,
+                    ),
+                  ),
+                  const SizedBox(height: 2),
+                  Text(
+                    subtitle,
+                    style: const TextStyle(
+                      color: Colors.white70,
+                      fontSize: 11,
+                      height: 1.25,
+                    ),
+                  ),
+                ],
+              ),
+            ),
+            Container(
+              width: 30,
+              height: 30,
+              decoration: BoxDecoration(
+                color: Colors.white.withValues(alpha: 0.2),
+                shape: BoxShape.circle,
+              ),
+              child: const Icon(
+                Icons.arrow_forward_rounded,
+                color: Colors.white,
+                size: 16,
+              ),
+            ),
+          ],
         ),
       ),
     );

--- a/lib/screens/n5_hero_number1_lesson_screen.dart
+++ b/lib/screens/n5_hero_number1_lesson_screen.dart
@@ -1,0 +1,4992 @@
+// ignore_for_file: deprecated_member_use
+
+import 'dart:async';
+import 'dart:math' as math;
+
+import 'package:confetti/confetti.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_tts/flutter_tts.dart';
+import 'package:get/get.dart';
+import 'package:speech_to_text/speech_recognition_result.dart';
+import 'package:speech_to_text/speech_to_text.dart';
+
+class N5HeroNumber1LessonScreen extends StatefulWidget {
+  const N5HeroNumber1LessonScreen({super.key});
+
+  @override
+  State<N5HeroNumber1LessonScreen> createState() => _N5HeroNumber1LessonScreenState();
+}
+
+enum _HeroTab { speak, match, blitz, tapHear, read, order, speakSeq }
+
+class _N5HeroNumber1LessonScreenState extends State<N5HeroNumber1LessonScreen> {
+  static const _tabs = [
+    _HeroTab.tapHear,
+    _HeroTab.read,
+    _HeroTab.order,
+    _HeroTab.speakSeq,
+    _HeroTab.speak,
+    _HeroTab.match,
+    _HeroTab.blitz,
+  ];
+  int _tab = 0;
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      backgroundColor: const Color(0xFF0F172A),
+      body: SafeArea(
+        child: Column(
+          children: [
+            Padding(
+              padding: const EdgeInsets.fromLTRB(16, 10, 16, 12),
+              child: Row(
+                children: [
+                  GestureDetector(
+                    onTap: Get.back,
+                    child: Container(
+                      width: 40,
+                      height: 40,
+                      decoration: BoxDecoration(
+                        color: Colors.white.withValues(alpha: 0.18),
+                        shape: BoxShape.circle,
+                      ),
+                      child: const Icon(Icons.arrow_back_rounded, color: Colors.white),
+                    ),
+                  ),
+                  const SizedBox(width: 10),
+                  Expanded(
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        const Text('হিরো নাম্বার ১',
+                            style: TextStyle(
+                                color: Colors.white, fontWeight: FontWeight.w900, fontSize: 18)),
+                        Text('১-১০ সংখ্যা: কানজি + হিরাগানা -> বাংলা',
+                            style: TextStyle(
+                                color: Colors.white.withValues(alpha: 0.75),
+                                fontWeight: FontWeight.w600,
+                                fontSize: 12)),
+                      ],
+                    ),
+                  ),
+                ],
+              ),
+            ),
+            Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 16),
+              child: _HeroTabPills(
+                index: _tab,
+                onChange: (i) => setState(() => _tab = i),
+              ),
+            ),
+            const SizedBox(height: 10),
+            Expanded(
+              child: AnimatedSwitcher(
+                duration: const Duration(milliseconds: 220),
+                child: switch (_tabs[_tab]) {
+                  _HeroTab.speak => const _HeroSpeakGame(key: ValueKey('heroSpeak')),
+                  _HeroTab.match => const _HeroMatchGame(key: ValueKey('heroMatch')),
+                  _HeroTab.blitz => const _HeroBlitzGame(key: ValueKey('heroBlitz')),
+                  _HeroTab.tapHear => const _HeroTapWhatYouHearGame(key: ValueKey('heroTapHear')),
+                  _HeroTab.read => const _HeroReadGame(key: ValueKey('heroRead')),
+                  _HeroTab.order => const _HeroOrderGame(key: ValueKey('heroOrder')),
+                  _HeroTab.speakSeq => const _HeroSpeakSequenceGame(key: ValueKey('heroSpeakSeq')),
+                },
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _HeroNum {
+  const _HeroNum({
+    required this.n,
+    required this.kanji,
+    required this.kana,
+    required this.romaji,
+    required this.bnPronunciation,
+    required this.bnDigit,
+    required this.bnWord,
+  });
+  final int n;
+  final String kanji;
+  final String kana;
+  final String romaji;
+  final String bnPronunciation;
+  final String bnDigit;
+  final String bnWord;
+}
+
+const _heroNumbers = <_HeroNum>[
+  _HeroNum(
+      n: 1,
+      kanji: '一',
+      kana: 'いち',
+      romaji: 'ichi',
+      bnPronunciation: 'ইচি',
+      bnDigit: '১',
+      bnWord: 'এক'),
+  _HeroNum(
+      n: 2,
+      kanji: '二',
+      kana: 'に',
+      romaji: 'ni',
+      bnPronunciation: 'নি',
+      bnDigit: '২',
+      bnWord: 'দুই'),
+  _HeroNum(
+      n: 3,
+      kanji: '三',
+      kana: 'さん',
+      romaji: 'san',
+      bnPronunciation: 'সান',
+      bnDigit: '৩',
+      bnWord: 'তিন'),
+  _HeroNum(
+      n: 4,
+      kanji: '四',
+      kana: 'よん',
+      romaji: 'yon',
+      bnPronunciation: 'ইয়োন',
+      bnDigit: '৪',
+      bnWord: 'চার'),
+  _HeroNum(
+      n: 5,
+      kanji: '五',
+      kana: 'ご',
+      romaji: 'go',
+      bnPronunciation: 'গো',
+      bnDigit: '৫',
+      bnWord: 'পাঁচ'),
+  _HeroNum(
+      n: 6,
+      kanji: '六',
+      kana: 'ろく',
+      romaji: 'roku',
+      bnPronunciation: 'রোকু',
+      bnDigit: '৬',
+      bnWord: 'ছয়'),
+  _HeroNum(
+      n: 7,
+      kanji: '七',
+      kana: 'なな',
+      romaji: 'nana',
+      bnPronunciation: 'নানা',
+      bnDigit: '৭',
+      bnWord: 'সাত'),
+  _HeroNum(
+      n: 8,
+      kanji: '八',
+      kana: 'はち',
+      romaji: 'hachi',
+      bnPronunciation: 'হাচি',
+      bnDigit: '৮',
+      bnWord: 'আট'),
+  _HeroNum(
+      n: 9,
+      kanji: '九',
+      kana: 'きゅう',
+      romaji: 'kyuu',
+      bnPronunciation: 'কিউ',
+      bnDigit: '৯',
+      bnWord: 'নয়'),
+  _HeroNum(
+      n: 10,
+      kanji: '十',
+      kana: 'じゅう',
+      romaji: 'juu',
+      bnPronunciation: 'জু',
+      bnDigit: '১০',
+      bnWord: 'দশ'),
+];
+
+class _HeroTabPills extends StatelessWidget {
+  const _HeroTabPills({required this.index, required this.onChange});
+  final int index;
+  final ValueChanged<int> onChange;
+
+  @override
+  Widget build(BuildContext context) {
+    const labels = ['শুনে ট্যাপ', 'পড়া মাস্টার', 'সাজাও', '১-১০ বলো', 'বলতে পারো', 'ম্যাচ মাস্টার', 'স্পিড বস'];
+    return Container(
+      padding: const EdgeInsets.all(6),
+      decoration: BoxDecoration(
+        color: const Color(0xFF1E293B),
+        borderRadius: BorderRadius.circular(14),
+        border: Border.all(color: Colors.white.withValues(alpha: 0.08)),
+      ),
+      child: SingleChildScrollView(
+        scrollDirection: Axis.horizontal,
+        child: Row(
+          children: [
+            for (var i = 0; i < labels.length; i++) ...[
+              GestureDetector(
+                onTap: () => onChange(i),
+                child: AnimatedContainer(
+                  duration: const Duration(milliseconds: 180),
+                  padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 10),
+                  decoration: BoxDecoration(
+                    color: i == index ? const Color(0xFF3B82F6) : Colors.transparent,
+                    borderRadius: BorderRadius.circular(10),
+                  ),
+                  child: Text(labels[i],
+                      style: const TextStyle(
+                          color: Colors.white, fontWeight: FontWeight.w900, fontSize: 12)),
+                ),
+              ),
+              if (i != labels.length - 1) const SizedBox(width: 6),
+            ]
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _HeroSpeakGame extends StatefulWidget {
+  const _HeroSpeakGame({super.key});
+
+  @override
+  State<_HeroSpeakGame> createState() => _HeroSpeakGameState();
+}
+
+class _HeroSpeakGameState extends State<_HeroSpeakGame>
+    with TickerProviderStateMixin {
+  final _rng = math.Random();
+  final _tts = FlutterTts();
+  final _stt = SpeechToText();
+  bool _ttsReady = false;
+  bool _sttReady = false;
+  String? _locale;
+  late _HeroNum _target;
+  String _heard = '';
+  bool _listening = false;
+  bool _grading = false;
+  int? _lastScore;
+  Set<int> _matchedKanaIdx = {};
+  bool _slowMode = false;
+  String _status = 'মাইক চাপো এবং উচ্চারণ বলো';
+  String? _error;
+  int _attempts = 0;
+  int _correct = 0;
+  int _streak = 0;
+  final Map<int, int> _missed = {};
+  Timer? _recordTimer;
+  Timer? _gradingTimer;
+  int _recordSecondsLeft = 0;
+  int _score = 0;
+  int _totalXp = 0;
+  double _soundLevel = 0;
+  late final AnimationController _waveCtrl;
+  late final AnimationController _pulseCtrl;
+  late final AnimationController _badgePopCtrl;
+
+  @override
+  void initState() {
+    super.initState();
+    _target = _heroNumbers[_rng.nextInt(_heroNumbers.length)];
+    _waveCtrl = AnimationController(
+      vsync: this,
+      duration: const Duration(milliseconds: 900),
+    )..repeat();
+    _pulseCtrl = AnimationController(
+      vsync: this,
+      duration: const Duration(milliseconds: 1100),
+    )..repeat(reverse: true);
+    _badgePopCtrl = AnimationController(
+      vsync: this,
+      duration: const Duration(milliseconds: 420),
+    );
+    _initTts();
+    _initStt();
+  }
+
+  Future<void> _initTts() async {
+    try {
+      await _tts.setLanguage('ja-JP');
+      await _tts.setSpeechRate(_slowMode ? 0.30 : 0.50);
+      if (!mounted) return;
+      setState(() => _ttsReady = true);
+    } catch (_) {}
+  }
+
+  Future<void> _initStt() async {
+    try {
+      final ok = await _stt.initialize(
+        onError: (e) {
+          if (!mounted) return;
+          setState(() => _error = e.errorMsg);
+        },
+        onStatus: (_) {},
+      );
+      if (!mounted) return;
+      if (!ok) {
+        setState(() => _sttReady = false);
+        return;
+      }
+      final locales = await _stt.locales();
+      final ja = locales.where((l) => l.localeId.toLowerCase().startsWith('ja'));
+      setState(() {
+        _locale = ja.isNotEmpty ? ja.first.localeId : (locales.isNotEmpty ? locales.first.localeId : null);
+        _sttReady = true;
+      });
+    } catch (e) {
+      if (!mounted) return;
+      setState(() {
+        _sttReady = false;
+        _error = '$e';
+      });
+    }
+  }
+
+  Future<void> _speakModel({bool? slow}) async {
+    if (!_ttsReady) return;
+    final useSlow = slow ?? _slowMode;
+    HapticFeedback.selectionClick();
+    await _tts.stop();
+    await _tts.setSpeechRate(useSlow ? 0.30 : 0.50);
+    await _tts.speak(_target.kana);
+  }
+
+  Future<void> _toggleSlow() async {
+    setState(() => _slowMode = !_slowMode);
+    await _speakModel(slow: _slowMode);
+  }
+
+  Future<void> _compareNative() async {
+    if (!_ttsReady) return;
+    HapticFeedback.selectionClick();
+    await _tts.stop();
+    await _tts.setSpeechRate(0.50);
+    await _tts.speak(_target.kana);
+    await Future.delayed(const Duration(milliseconds: 900));
+    await _tts.setSpeechRate(0.30);
+    await _tts.speak(_target.kana);
+  }
+
+  String _norm(String s) {
+    final lower = s.toLowerCase();
+    final sb = StringBuffer();
+    for (final r in lower.runes) {
+      final ascii = (r >= 0x30 && r <= 0x39) || (r >= 0x61 && r <= 0x7A);
+      final jp = (r >= 0x3040 && r <= 0x30FF) || (r >= 0x4E00 && r <= 0x9FFF);
+      if (ascii || jp) sb.write(String.fromCharCode(r));
+    }
+    return sb.toString();
+  }
+
+  ({int score, Set<int> matchedIdx}) _grade(String raw, _HeroNum target) {
+    final heard = _norm(raw);
+    final kana = _norm(target.kana);
+    final romaji = _norm(target.romaji);
+    final kanji = _norm(target.kanji);
+    final digit = target.n.toString();
+    if (heard.isEmpty) return (score: 0, matchedIdx: <int>{});
+
+    int base;
+    if (heard == kana || heard == romaji || heard == kanji || heard == digit) {
+      base = 100;
+    } else if (heard.contains(kana)) {
+      base = 96;
+    } else if (heard.contains(romaji)) {
+      base = 92;
+    } else if (kanji.isNotEmpty && heard.contains(kanji)) {
+      base = 90;
+    } else if (heard.contains(digit)) {
+      base = 88;
+    } else {
+      final ref = kana.isNotEmpty ? kana : romaji;
+      base = (_similarity(heard, ref) * 70).round();
+    }
+
+    final matchedIdx = <int>{};
+    final kanaRunes = target.kana.runes.toList();
+    final remaining = heard.runes.toList();
+    for (var i = 0; i < kanaRunes.length; i++) {
+      final idx = remaining.indexOf(kanaRunes[i]);
+      if (idx >= 0) {
+        matchedIdx.add(i);
+        remaining.removeAt(idx);
+      }
+    }
+    if (base >= 88 && matchedIdx.isEmpty) {
+      for (var i = 0; i < kanaRunes.length; i++) {
+        matchedIdx.add(i);
+      }
+    }
+    return (score: base.clamp(0, 100), matchedIdx: matchedIdx);
+  }
+
+  double _similarity(String a, String b) {
+    if (b.isEmpty) return 0;
+    int matches = 0;
+    final remaining = a.split('').toList();
+    for (final c in b.split('')) {
+      final idx = remaining.indexOf(c);
+      if (idx >= 0) {
+        matches++;
+        remaining.removeAt(idx);
+      }
+    }
+    return matches / b.length;
+  }
+
+  Future<void> _start() async {
+    if (_listening || _grading) return;
+    HapticFeedback.mediumImpact();
+    setState(() {
+      _heard = '';
+      _error = null;
+      _lastScore = null;
+      _matchedKanaIdx = {};
+      _status = 'রেকর্ডিং শুরু হচ্ছে...';
+      _recordSecondsLeft = 5;
+      _soundLevel = 0;
+    });
+    try {
+      if (!_sttReady) {
+        await _initStt();
+      }
+      if (!_sttReady) {
+        throw Exception('Speech recognition এই ডিভাইসে কাজ করছে না।');
+      }
+      await _stt.listen(
+        localeId: _locale,
+        listenMode: ListenMode.confirmation,
+        partialResults: true,
+        cancelOnError: true,
+        onResult: (SpeechRecognitionResult r) {
+          if (!mounted) return;
+          setState(() => _heard = r.recognizedWords);
+        },
+        onSoundLevelChange: (level) {
+          if (!mounted) return;
+          setState(() => _soundLevel = level);
+        },
+      );
+      if (!mounted) return;
+      setState(() {
+        _listening = true;
+        _status = 'রেকর্ড হচ্ছে...';
+      });
+      _recordTimer?.cancel();
+      _recordTimer = Timer.periodic(const Duration(seconds: 1), (_) async {
+        if (!mounted || !_listening) return;
+        if (_recordSecondsLeft <= 1) {
+          await _stopAndCheck();
+          return;
+        }
+        setState(() {
+          _recordSecondsLeft -= 1;
+        });
+      });
+    } catch (e) {
+      if (!mounted) return;
+      HapticFeedback.lightImpact();
+      _recordTimer?.cancel();
+      setState(() {
+        _listening = false;
+        _error = '$e';
+        _status = 'রেকর্ডিং শুরু হয়নি';
+        _recordSecondsLeft = 0;
+      });
+    }
+  }
+
+  Future<void> _stopAndCheck() async {
+    if (!_listening) return;
+    _recordTimer?.cancel();
+    HapticFeedback.selectionClick();
+    await _stt.stop();
+    final heardNorm = _norm(_heard);
+    if (!mounted) return;
+    setState(() {
+      _listening = false;
+      _recordSecondsLeft = 0;
+      _soundLevel = 0;
+      if (heardNorm.isEmpty) {
+        _lastScore = 0;
+        _matchedKanaIdx = {};
+        _status = 'কিছু শোনা যায়নি — আবার চেষ্টা করো';
+        _streak = 0;
+      } else {
+        _grading = true;
+        _status = 'Grading your recording now...';
+      }
+    });
+    if (heardNorm.isEmpty) return;
+
+    final result = _grade(_heard, _target);
+    _gradingTimer?.cancel();
+    _gradingTimer = Timer(const Duration(milliseconds: 1400), () {
+      if (!mounted) return;
+      final ok = result.score >= 80;
+      setState(() {
+        _grading = false;
+        _lastScore = result.score;
+        _matchedKanaIdx = result.matchedIdx;
+        _attempts += 1;
+        if (ok) {
+          _streak += 1;
+          _correct += 1;
+          _score += 10;
+          _totalXp += 10;
+          _status = result.score >= 90 ? 'দারুণ! সঠিক উচ্চারণ' : 'ভালো হয়েছে!';
+          HapticFeedback.lightImpact();
+        } else {
+          _streak = 0;
+          _missed[_target.n] = (_missed[_target.n] ?? 0) + 1;
+          _status = 'আরেকবার চেষ্টা করো';
+        }
+      });
+      _badgePopCtrl.forward(from: 0);
+    });
+  }
+
+  void _next() {
+    setState(() {
+      _target = _heroNumbers[_rng.nextInt(_heroNumbers.length)];
+      _heard = '';
+      _lastScore = null;
+      _matchedKanaIdx = {};
+      _status = 'মাইক চাপো এবং উচ্চারণ বলো';
+    });
+  }
+
+  @override
+  void dispose() {
+    _recordTimer?.cancel();
+    _gradingTimer?.cancel();
+    _waveCtrl.dispose();
+    _pulseCtrl.dispose();
+    _badgePopCtrl.dispose();
+    _stt.stop();
+    _tts.stop();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final score = _lastScore;
+    final scoreColor = score == null
+        ? Colors.transparent
+        : (score >= 90 ? const Color(0xFF22C55E) : const Color(0xFFFFA726));
+    return SingleChildScrollView(
+      padding: const EdgeInsets.fromLTRB(16, 0, 16, 16),
+      child: Column(children: [
+        _TopBar(score: _score, lives: 3),
+        const SizedBox(height: 12),
+        _SpeechCard(
+          target: _target,
+          matchedIdx: _matchedKanaIdx,
+          showHighlight: _lastScore != null,
+          scoreBadge: score == null
+              ? null
+              : ScaleTransition(
+                  scale: CurvedAnimation(parent: _badgePopCtrl, curve: Curves.elasticOut),
+                  child: _ScoreBadge(score: score, color: scoreColor),
+                ),
+        ),
+        const SizedBox(height: 18),
+        _UtilityRow(
+          slow: _slowMode,
+          onSlow: _toggleSlow,
+          onPlay: () => _speakModel(slow: false),
+          onCompare: _compareNative,
+          disabled: _listening || _grading,
+        ),
+        const SizedBox(height: 18),
+        _MicButton(
+          listening: _listening,
+          grading: _grading,
+          pulse: _pulseCtrl,
+          onTap: _grading
+              ? () {}
+              : (_listening ? _stopAndCheck : _start),
+        ),
+        const SizedBox(height: 14),
+        SizedBox(
+          height: 56,
+          child: _listening
+              ? _WaveformBars(level: _soundLevel, anim: _waveCtrl)
+              : (_grading
+                  ? const _GradingDots()
+                  : _StatusLine(
+                      status: _status,
+                      lastScore: _lastScore,
+                    )),
+        ),
+        if (_heard.isNotEmpty) ...[
+          const SizedBox(height: 6),
+          Text(
+            'শোনা: $_heard',
+            style: TextStyle(
+              color: Colors.white.withValues(alpha: 0.7),
+              fontWeight: FontWeight.w600,
+            ),
+          ),
+        ],
+        if (_error != null) ...[
+          const SizedBox(height: 6),
+          Text(_error!,
+              style: TextStyle(color: Colors.red.shade300, fontWeight: FontWeight.w700)),
+        ],
+        const SizedBox(height: 18),
+        Row(children: [
+          Expanded(
+            child: OutlinedButton.icon(
+              onPressed: _attempts == 0 && _missed.isEmpty
+                  ? null
+                  : () => _showAwesomeResult(
+                        context: context,
+                        title: 'বলতে পারো — রিভিউ',
+                        scoreLabel: '+$_totalXp XP',
+                        stats: [
+                          'চেষ্টা: $_attempts',
+                          'সঠিক: $_correct',
+                          'Accuracy: ${_attempts == 0 ? 0 : ((_correct * 100) / _attempts).round()}%',
+                          'সেরা স্ট্রিক: $_streak',
+                        ],
+                        missedLines: _missed.entries.toList()
+                          ..sort((a, b) => b.value.compareTo(a.value)),
+                        onPlayAgain: () {
+                          setState(() {
+                            _score = 0;
+                            _attempts = 0;
+                            _correct = 0;
+                            _streak = 0;
+                            _totalXp = 0;
+                            _missed.clear();
+                            _heard = '';
+                            _status = 'মাইক চাপো এবং উচ্চারণ বলো';
+                            _lastScore = null;
+                            _matchedKanaIdx = {};
+                          });
+                        },
+                      ),
+              style: OutlinedButton.styleFrom(
+                side: BorderSide(color: Colors.white.withValues(alpha: 0.2)),
+                foregroundColor: Colors.white,
+                padding: const EdgeInsets.symmetric(vertical: 14),
+              ),
+              icon: const Icon(Icons.insights_rounded),
+              label: const Text('রিভিউ', style: TextStyle(fontWeight: FontWeight.w900)),
+            ),
+          ),
+          const SizedBox(width: 10),
+          Expanded(
+            child: ElevatedButton.icon(
+              onPressed: _grading ? null : _next,
+              style: ElevatedButton.styleFrom(
+                backgroundColor: const Color(0xFFFFE000),
+                foregroundColor: const Color(0xFF1E293B),
+                padding: const EdgeInsets.symmetric(vertical: 14),
+              ),
+              icon: const Icon(Icons.navigate_next_rounded),
+              label: const Text('পরের সংখ্যা', style: TextStyle(fontWeight: FontWeight.w900)),
+            ),
+          ),
+        ])
+      ]),
+    );
+  }
+}
+
+class _SpeechCard extends StatelessWidget {
+  const _SpeechCard({
+    required this.target,
+    required this.matchedIdx,
+    required this.showHighlight,
+    this.scoreBadge,
+  });
+  final _HeroNum target;
+  final Set<int> matchedIdx;
+  final bool showHighlight;
+  final Widget? scoreBadge;
+
+  @override
+  Widget build(BuildContext context) {
+    final kanaRunes = target.kana.runes.toList();
+    return Stack(
+      clipBehavior: Clip.none,
+      children: [
+        Container(
+          width: double.infinity,
+          padding: const EdgeInsets.fromLTRB(16, 18, 16, 18),
+          decoration: _cardDeco(),
+          child: Row(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Container(
+                width: 56,
+                height: 56,
+                decoration: BoxDecoration(
+                  shape: BoxShape.circle,
+                  gradient: const LinearGradient(
+                    colors: [Color(0xFFFFE000), Color(0xFFFFA726)],
+                    begin: Alignment.topLeft,
+                    end: Alignment.bottomRight,
+                  ),
+                  border: Border.all(
+                      color: Colors.white.withValues(alpha: 0.25), width: 2),
+                ),
+                alignment: Alignment.center,
+                child: const Text('先生',
+                    style: TextStyle(
+                        color: Color(0xFF1E293B),
+                        fontWeight: FontWeight.w900,
+                        fontSize: 16)),
+              ),
+              const SizedBox(width: 12),
+              Expanded(
+                child: Stack(
+                  clipBehavior: Clip.none,
+                  children: [
+                    Positioned(
+                      left: -8,
+                      top: 16,
+                      child: CustomPaint(
+                        size: const Size(10, 14),
+                        painter: _BubbleTailPainter(),
+                      ),
+                    ),
+                    Container(
+                      padding: const EdgeInsets.fromLTRB(14, 12, 14, 14),
+                      decoration: BoxDecoration(
+                        color: Colors.white,
+                        borderRadius: BorderRadius.circular(16),
+                      ),
+                      child: Column(
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        children: [
+                          Text(
+                            target.kanji,
+                            style: const TextStyle(
+                                color: Color(0xFF1E293B),
+                                fontSize: 42,
+                                fontWeight: FontWeight.w900,
+                                height: 1.0),
+                          ),
+                          const SizedBox(height: 6),
+                          Wrap(
+                            children: [
+                              for (var i = 0; i < kanaRunes.length; i++)
+                                _KanaChar(
+                                  ch: String.fromCharCode(kanaRunes[i]),
+                                  highlight:
+                                      showHighlight && matchedIdx.contains(i),
+                                ),
+                            ],
+                          ),
+                          const SizedBox(height: 4),
+                          Text(
+                            target.romaji,
+                            style: const TextStyle(
+                              color: Color(0xFF64748B),
+                              fontSize: 16,
+                              fontWeight: FontWeight.w700,
+                              letterSpacing: 0.5,
+                            ),
+                          ),
+                          const SizedBox(height: 8),
+                          Text(
+                            'উচ্চারণ: ${target.bnPronunciation}',
+                            style: const TextStyle(
+                              color: Color(0xFF334155),
+                              fontWeight: FontWeight.w700,
+                            ),
+                          ),
+                          const SizedBox(height: 2),
+                          Text(
+                            'বাংলা: ${target.bnDigit} ${target.bnWord}',
+                            style: const TextStyle(
+                              color: Color(0xFF1E293B),
+                              fontWeight: FontWeight.w900,
+                            ),
+                          ),
+                        ],
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+            ],
+          ),
+        ),
+        if (scoreBadge != null)
+          Positioned(top: -10, right: -6, child: scoreBadge!),
+      ],
+    );
+  }
+}
+
+class _KanaChar extends StatelessWidget {
+  const _KanaChar({required this.ch, required this.highlight});
+  final String ch;
+  final bool highlight;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      margin: const EdgeInsets.only(right: 2),
+      padding: const EdgeInsets.only(bottom: 2),
+      decoration: BoxDecoration(
+        border: Border(
+          bottom: BorderSide(
+            color: highlight ? const Color(0xFF22C55E) : Colors.transparent,
+            width: 3,
+          ),
+        ),
+      ),
+      child: Text(
+        ch,
+        style: const TextStyle(
+          color: Color(0xFF1E293B),
+          fontSize: 26,
+          fontWeight: FontWeight.w900,
+        ),
+      ),
+    );
+  }
+}
+
+class _BubbleTailPainter extends CustomPainter {
+  @override
+  void paint(Canvas canvas, Size size) {
+    final paint = Paint()..color = Colors.white;
+    final path = Path()
+      ..moveTo(size.width, 0)
+      ..lineTo(0, size.height / 2)
+      ..lineTo(size.width, size.height)
+      ..close();
+    canvas.drawPath(path, paint);
+  }
+
+  @override
+  bool shouldRepaint(covariant CustomPainter oldDelegate) => false;
+}
+
+class _ScoreBadge extends StatelessWidget {
+  const _ScoreBadge({required this.score, required this.color});
+  final int score;
+  final Color color;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      width: 54,
+      height: 54,
+      decoration: BoxDecoration(
+        shape: BoxShape.circle,
+        color: color,
+        border: Border.all(color: Colors.white, width: 3),
+        boxShadow: [
+          BoxShadow(
+            color: color.withValues(alpha: 0.45),
+            blurRadius: 14,
+            offset: const Offset(0, 4),
+          ),
+        ],
+      ),
+      alignment: Alignment.center,
+      child: Text(
+        '$score',
+        style: const TextStyle(
+          color: Colors.white,
+          fontSize: 20,
+          fontWeight: FontWeight.w900,
+        ),
+      ),
+    );
+  }
+}
+
+class _UtilityRow extends StatelessWidget {
+  const _UtilityRow({
+    required this.slow,
+    required this.onSlow,
+    required this.onPlay,
+    required this.onCompare,
+    required this.disabled,
+  });
+  final bool slow;
+  final VoidCallback onSlow;
+  final VoidCallback onPlay;
+  final VoidCallback onCompare;
+  final bool disabled;
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      mainAxisAlignment: MainAxisAlignment.center,
+      children: [
+        _UtilityButton(
+          icon: Icons.pets_rounded,
+          active: slow,
+          onTap: disabled ? null : onSlow,
+          tooltip: 'ধীরে',
+        ),
+        const SizedBox(width: 18),
+        _UtilityButton(
+          icon: Icons.volume_up_rounded,
+          onTap: disabled ? null : onPlay,
+          tooltip: 'শুনি',
+        ),
+        const SizedBox(width: 18),
+        _UtilityButton(
+          icon: Icons.compare_arrows_rounded,
+          onTap: disabled ? null : onCompare,
+          tooltip: 'তুলনা',
+        ),
+      ],
+    );
+  }
+}
+
+class _UtilityButton extends StatelessWidget {
+  const _UtilityButton({
+    required this.icon,
+    required this.onTap,
+    this.active = false,
+    this.tooltip,
+  });
+  final IconData icon;
+  final VoidCallback? onTap;
+  final bool active;
+  final String? tooltip;
+
+  @override
+  Widget build(BuildContext context) {
+    final bg = active
+        ? const Color(0xFFFFE000)
+        : Colors.white.withValues(alpha: 0.10);
+    final fg = active ? const Color(0xFF1E293B) : Colors.white;
+    return GestureDetector(
+      onTap: onTap,
+      child: Container(
+        width: 48,
+        height: 48,
+        decoration: BoxDecoration(
+          color: bg,
+          shape: BoxShape.circle,
+          border: Border.all(color: Colors.white.withValues(alpha: 0.18)),
+        ),
+        child: Icon(icon, color: fg, size: 24),
+      ),
+    );
+  }
+}
+
+class _MicButton extends StatelessWidget {
+  const _MicButton({
+    required this.listening,
+    required this.grading,
+    required this.pulse,
+    required this.onTap,
+  });
+  final bool listening;
+  final bool grading;
+  final Animation<double> pulse;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    final base = listening ? const Color(0xFFEF4444) : const Color(0xFFFF6B35);
+    return GestureDetector(
+      onTap: onTap,
+      child: AnimatedBuilder(
+        animation: pulse,
+        builder: (_, __) {
+          final scale = listening ? 1.0 + (pulse.value * 0.08) : 1.0;
+          return Transform.scale(
+            scale: scale,
+            child: Container(
+              width: 96,
+              height: 96,
+              decoration: BoxDecoration(
+                shape: BoxShape.circle,
+                color: grading ? Colors.grey.shade600 : base,
+                boxShadow: [
+                  BoxShadow(
+                    color: base.withValues(alpha: 0.45),
+                    blurRadius: 22,
+                    spreadRadius: listening ? 4 : 0,
+                  ),
+                ],
+                border: Border.all(color: Colors.white, width: 4),
+              ),
+              child: Icon(
+                listening ? Icons.stop_rounded : Icons.mic_rounded,
+                color: Colors.white,
+                size: 42,
+              ),
+            ),
+          );
+        },
+      ),
+    );
+  }
+}
+
+class _WaveformBars extends StatelessWidget {
+  const _WaveformBars({required this.level, required this.anim});
+  final double level;
+  final Animation<double> anim;
+
+  @override
+  Widget build(BuildContext context) {
+    return AnimatedBuilder(
+      animation: anim,
+      builder: (_, __) {
+        final base = (level.clamp(-2, 12) + 2) / 14; // 0..1 roughly
+        return Row(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: List.generate(11, (i) {
+            final phase = (anim.value * 2 * math.pi) + (i * 0.55);
+            final wob = 0.55 + 0.45 * math.sin(phase).abs();
+            final h = (8 + base * 36 * wob + 4 * math.sin(phase * 1.7)).clamp(6.0, 52.0);
+            return Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 3),
+              child: Container(
+                width: 6,
+                height: h,
+                decoration: BoxDecoration(
+                  color: const Color(0xFFFF7B9C),
+                  borderRadius: BorderRadius.circular(3),
+                ),
+              ),
+            );
+          }),
+        );
+      },
+    );
+  }
+}
+
+class _GradingDots extends StatefulWidget {
+  const _GradingDots();
+  @override
+  State<_GradingDots> createState() => _GradingDotsState();
+}
+
+class _GradingDotsState extends State<_GradingDots>
+    with SingleTickerProviderStateMixin {
+  late final AnimationController _c;
+  @override
+  void initState() {
+    super.initState();
+    _c = AnimationController(
+      vsync: this,
+      duration: const Duration(milliseconds: 1100),
+    )..repeat();
+  }
+
+  @override
+  void dispose() {
+    _c.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return AnimatedBuilder(
+      animation: _c,
+      builder: (_, __) {
+        return Row(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            const Text(
+              'Grading your recording now',
+              style: TextStyle(
+                color: Colors.white,
+                fontWeight: FontWeight.w900,
+                fontSize: 15,
+              ),
+            ),
+            for (var i = 0; i < 3; i++)
+              Padding(
+                padding: const EdgeInsets.only(left: 4),
+                child: Opacity(
+                  opacity: ((_c.value * 3 + i / 3) % 1.0 > 0.5) ? 1.0 : 0.3,
+                  child: const Text('.',
+                      style: TextStyle(
+                          color: Colors.white,
+                          fontWeight: FontWeight.w900,
+                          fontSize: 22)),
+                ),
+              ),
+          ],
+        );
+      },
+    );
+  }
+}
+
+class _StatusLine extends StatelessWidget {
+  const _StatusLine({required this.status, required this.lastScore});
+  final String status;
+  final int? lastScore;
+
+  @override
+  Widget build(BuildContext context) {
+    final ok = lastScore != null && lastScore! >= 80;
+    final showXp = lastScore != null && lastScore! >= 80;
+    return Column(
+      mainAxisAlignment: MainAxisAlignment.center,
+      children: [
+        Row(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            if (lastScore != null) ...[
+              Icon(
+                ok ? Icons.check_circle_rounded : Icons.cancel_rounded,
+                color: ok ? const Color(0xFF22C55E) : const Color(0xFFEF4444),
+                size: 20,
+              ),
+              const SizedBox(width: 6),
+            ],
+            Text(
+              status,
+              style: const TextStyle(
+                color: Colors.white,
+                fontWeight: FontWeight.w900,
+                fontSize: 15,
+              ),
+            ),
+            if (showXp) ...[
+              const SizedBox(width: 8),
+              Container(
+                padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 2),
+                decoration: BoxDecoration(
+                  color: const Color(0xFFFFE000),
+                  borderRadius: BorderRadius.circular(10),
+                ),
+                child: Text(
+                  '+${lastScore! >= 90 ? 30 : 20} XP',
+                  style: const TextStyle(
+                    color: Color(0xFF1E293B),
+                    fontWeight: FontWeight.w900,
+                    fontSize: 12,
+                  ),
+                ),
+              ),
+            ],
+          ],
+        ),
+      ],
+    );
+  }
+}
+
+class _HeroPair {
+  const _HeroPair({required this.id, required this.n, required this.label, required this.jp});
+  final String id;
+  final int n;
+  final String label;
+  final bool jp;
+}
+
+class _HeroMatchGame extends StatefulWidget {
+  const _HeroMatchGame({super.key});
+  @override
+  State<_HeroMatchGame> createState() => _HeroMatchGameState();
+}
+
+class _HeroMatchGameState extends State<_HeroMatchGame>
+    with TickerProviderStateMixin {
+  final _rng = math.Random();
+  final _tts = FlutterTts();
+  late ConfettiController _confetti;
+  late AnimationController _shakeCtrl;
+  bool _ttsReady = false;
+
+  late List<_HeroPair> _cards;
+  String? _picked;
+  int? _pickedN;
+  final _matched = <String>{};
+  final Map<int, int> _missesByPair = {};
+  int _moves = 0;
+  int _wrongMoves = 0;
+  int _streak = 0;
+  int _bestStreak = 0;
+  int _xp = 0;
+  final Stopwatch _stopwatch = Stopwatch();
+  Timer? _ticker;
+  String _wrongId = '';
+
+  @override
+  void initState() {
+    super.initState();
+    _confetti = ConfettiController(duration: const Duration(milliseconds: 700));
+    _shakeCtrl =
+        AnimationController(vsync: this, duration: const Duration(milliseconds: 380));
+    _initTts();
+    _reset();
+  }
+
+  Future<void> _initTts() async {
+    try {
+      await _tts.setLanguage('ja-JP');
+      await _tts.setSpeechRate(0.50);
+      await _tts.setPitch(1.05);
+      if (!mounted) return;
+      setState(() => _ttsReady = true);
+    } catch (_) {}
+  }
+
+  void _reset() {
+    final pool = List<_HeroNum>.of(_heroNumbers)..shuffle(_rng);
+    final take = pool.take(6).toList();
+    final cards = <_HeroPair>[];
+    for (final n in take) {
+      cards.add(_HeroPair(
+          id: 'jp_${n.n}',
+          n: n.n,
+          label: '${n.kanji}\n${n.kana}\n(${n.bnPronunciation})',
+          jp: true));
+      cards.add(_HeroPair(
+          id: 'bn_${n.n}', n: n.n, label: '${n.bnDigit} ${n.bnWord}', jp: false));
+    }
+    cards.shuffle(_rng);
+    setState(() {
+      _cards = cards;
+      _picked = null;
+      _pickedN = null;
+      _matched.clear();
+      _missesByPair.clear();
+      _moves = 0;
+      _wrongMoves = 0;
+      _streak = 0;
+      _bestStreak = 0;
+      _xp = 0;
+      _wrongId = '';
+    });
+    _stopwatch
+      ..reset()
+      ..start();
+    _ticker?.cancel();
+    _ticker = Timer.periodic(const Duration(seconds: 1), (_) {
+      if (mounted) setState(() {});
+    });
+  }
+
+  Future<void> _speak(int n) async {
+    if (!_ttsReady) return;
+    final hero = _heroNumbers.firstWhere((x) => x.n == n);
+    await _tts.stop();
+    await _tts.speak(hero.kana);
+  }
+
+  void _tap(_HeroPair c) {
+    if (_matched.contains(c.id)) return;
+    if (c.jp) {
+      // ignore: discarded_futures
+      _speak(c.n);
+    }
+    if (_picked == null) {
+      HapticFeedback.selectionClick();
+      setState(() {
+        _picked = c.id;
+        _pickedN = c.n;
+      });
+      return;
+    }
+    if (_picked == c.id) return;
+    _moves += 1;
+    final ok = _pickedN == c.n;
+    if (ok) {
+      HapticFeedback.mediumImpact();
+      setState(() {
+        _matched.add(_picked!);
+        _matched.add(c.id);
+        _picked = null;
+        _pickedN = null;
+        _streak += 1;
+        if (_streak > _bestStreak) _bestStreak = _streak;
+        _xp += 10;
+      });
+      _confetti.play();
+      if (_matched.length == _cards.length) {
+        _stopwatch.stop();
+        _ticker?.cancel();
+        Future.delayed(const Duration(milliseconds: 600), () {
+          if (!mounted) return;
+          _showAwesomeResult(
+            context: context,
+            title: 'ম্যাচ মাস্টার — সব মিলেছে',
+            scoreLabel: 'XP: $_xp',
+            stats: [
+              'মুভ: $_moves',
+              'ভুল: $_wrongMoves',
+              'নির্ভুলতা: ${_moves == 0 ? 0 : (((_moves - _wrongMoves) * 100) / _moves).round()}%',
+              'সেরা স্ট্রিক: $_bestStreak',
+              'সময়: ${_formatDuration(_stopwatch.elapsed)}',
+            ],
+            missedLines: _missesByPair.entries.toList()
+              ..sort((a, b) => b.value.compareTo(a.value)),
+            onPlayAgain: _reset,
+          );
+        });
+      }
+    } else {
+      HapticFeedback.heavyImpact();
+      _wrongMoves += 1;
+      _missesByPair[c.n] = (_missesByPair[c.n] ?? 0) + 1;
+      _missesByPair[_pickedN!] = (_missesByPair[_pickedN!] ?? 0) + 1;
+      final now = c.id;
+      setState(() {
+        _wrongId = now;
+        _picked = now;
+        _pickedN = c.n;
+        _streak = 0;
+      });
+      _shakeCtrl.forward(from: 0);
+      Future.delayed(const Duration(milliseconds: 520), () {
+        if (!mounted) return;
+        setState(() {
+          if (_picked == now) {
+            _picked = null;
+            _pickedN = null;
+          }
+          _wrongId = '';
+        });
+      });
+    }
+  }
+
+  String _formatDuration(Duration d) {
+    final m = d.inMinutes.remainder(60).toString().padLeft(2, '0');
+    final s = d.inSeconds.remainder(60).toString().padLeft(2, '0');
+    return '$m:$s';
+  }
+
+  @override
+  void dispose() {
+    _confetti.dispose();
+    _shakeCtrl.dispose();
+    _ticker?.cancel();
+    _tts.stop();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final progress = _cards.isEmpty ? 0.0 : _matched.length / _cards.length;
+    final elapsed = _formatDuration(_stopwatch.elapsed);
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(16, 0, 16, 16),
+      child: Stack(
+        clipBehavior: Clip.none,
+        children: [
+          Align(
+            alignment: Alignment.topCenter,
+            child: IgnorePointer(
+              child: SizedBox(
+                height: 140,
+                width: double.infinity,
+                child: ConfettiWidget(
+                  confettiController: _confetti,
+                  blastDirectionality: BlastDirectionality.explosive,
+                  maxBlastForce: 14,
+                  minBlastForce: 6,
+                  emissionFrequency: 0.08,
+                  numberOfParticles: 12,
+                  gravity: 0.22,
+                  shouldLoop: false,
+                  colors: const [
+                    Color(0xFFFFE000),
+                    Color(0xFF10B981),
+                    Color(0xFFFF8A34),
+                    Color(0xFF3B82F6),
+                  ],
+                ),
+              ),
+            ),
+          ),
+          Column(children: [
+            Container(
+              padding: const EdgeInsets.all(14),
+              decoration: _cardDeco(),
+              child: Column(
+                children: [
+                  Row(
+                    children: [
+                      const Icon(Icons.extension_rounded, color: Color(0xFFFFE000)),
+                      const SizedBox(width: 8),
+                      const Expanded(
+                        child: Text('জাপানি ↔ বাংলা মিলাও',
+                            style: TextStyle(
+                                color: Colors.white,
+                                fontWeight: FontWeight.w900)),
+                      ),
+                      _MatchStatChip(label: 'XP', value: '$_xp'),
+                      const SizedBox(width: 6),
+                      _MatchStatChip(label: 'স্ট্রিক', value: '$_streak'),
+                    ],
+                  ),
+                  const SizedBox(height: 8),
+                  Row(
+                    children: [
+                      Icon(Icons.timer_rounded,
+                          size: 14, color: Colors.white.withValues(alpha: 0.7)),
+                      const SizedBox(width: 4),
+                      Text(elapsed,
+                          style: TextStyle(
+                              color: Colors.white.withValues(alpha: 0.85),
+                              fontWeight: FontWeight.w800,
+                              fontSize: 12)),
+                      const SizedBox(width: 14),
+                      Text('মুভ: $_moves',
+                          style: TextStyle(
+                              color: Colors.white.withValues(alpha: 0.85),
+                              fontWeight: FontWeight.w800,
+                              fontSize: 12)),
+                      const Spacer(),
+                      Text('${_matched.length ~/ 2}/${_cards.length ~/ 2} মিলেছে',
+                          style: const TextStyle(
+                              color: Color(0xFFFFE000),
+                              fontWeight: FontWeight.w900,
+                              fontSize: 12)),
+                    ],
+                  ),
+                  const SizedBox(height: 8),
+                  LinearProgressIndicator(
+                    minHeight: 7,
+                    borderRadius: BorderRadius.circular(99),
+                    value: progress.clamp(0, 1),
+                    backgroundColor: Colors.white.withValues(alpha: 0.12),
+                    valueColor:
+                        const AlwaysStoppedAnimation(Color(0xFFFFE000)),
+                  ),
+                ],
+              ),
+            ),
+            const SizedBox(height: 10),
+            Expanded(
+              child: GridView.builder(
+                itemCount: _cards.length,
+                gridDelegate:
+                    const SliverGridDelegateWithFixedCrossAxisCount(
+                  crossAxisCount: 3,
+                  crossAxisSpacing: 10,
+                  mainAxisSpacing: 10,
+                  childAspectRatio: 1.05,
+                ),
+                itemBuilder: (_, i) {
+                  final c = _cards[i];
+                  final selected = _picked == c.id;
+                  final matched = _matched.contains(c.id);
+                  final wrong = _wrongId == c.id;
+                  final border = matched
+                      ? const Color(0xFF10B981)
+                      : wrong
+                          ? const Color(0xFFEF4444)
+                          : (selected
+                              ? const Color(0xFFFFE000)
+                              : Colors.white.withValues(alpha: 0.14));
+                  final bg = matched
+                      ? const Color(0xFF10B981).withValues(alpha: 0.18)
+                      : wrong
+                          ? const Color(0xFFEF4444).withValues(alpha: 0.18)
+                          : (selected
+                              ? const Color(0xFFFFE000).withValues(alpha: 0.14)
+                              : Colors.white.withValues(alpha: 0.06));
+                  return AnimatedBuilder(
+                    animation: _shakeCtrl,
+                    builder: (_, child) {
+                      final dx = wrong
+                          ? math.sin(_shakeCtrl.value * math.pi * 6) * 8
+                          : 0.0;
+                      return Transform.translate(
+                          offset: Offset(dx, 0), child: child);
+                    },
+                    child: GestureDetector(
+                      onTap: () => _tap(c),
+                      child: AnimatedScale(
+                        scale: matched ? 1.04 : (selected ? 1.02 : 1.0),
+                        duration: const Duration(milliseconds: 220),
+                        child: Container(
+                          decoration: BoxDecoration(
+                            color: bg,
+                            borderRadius: BorderRadius.circular(16),
+                            border: Border.all(
+                                color: border,
+                                width: selected || wrong ? 2.4 : 1.5),
+                          ),
+                          child: Stack(
+                            children: [
+                              Center(
+                                child: Padding(
+                                  padding: const EdgeInsets.all(6),
+                                  child: Text(
+                                    c.label,
+                                    textAlign: TextAlign.center,
+                                    style: TextStyle(
+                                      color: Colors.white,
+                                      fontWeight: FontWeight.w900,
+                                      fontSize: c.jp ? 18 : 14,
+                                    ),
+                                  ),
+                                ),
+                              ),
+                              if (c.jp)
+                                Positioned(
+                                  top: 4,
+                                  right: 4,
+                                  child: Container(
+                                    padding: const EdgeInsets.all(4),
+                                    decoration: BoxDecoration(
+                                      color: Colors.white
+                                          .withValues(alpha: 0.18),
+                                      shape: BoxShape.circle,
+                                    ),
+                                    child: const Icon(Icons.volume_up_rounded,
+                                        size: 12, color: Colors.white),
+                                  ),
+                                ),
+                              if (matched)
+                                const Positioned(
+                                  top: 4,
+                                  left: 4,
+                                  child: Icon(Icons.check_circle_rounded,
+                                      size: 16, color: Color(0xFF10B981)),
+                                ),
+                            ],
+                          ),
+                        ),
+                      ),
+                    ),
+                  );
+                },
+              ),
+            ),
+            SizedBox(
+              width: double.infinity,
+              child: OutlinedButton.icon(
+                onPressed: _reset,
+                style: OutlinedButton.styleFrom(
+                    side:
+                        BorderSide(color: Colors.white.withValues(alpha: 0.2)),
+                    foregroundColor: Colors.white),
+                icon: const Icon(Icons.refresh_rounded),
+                label: const Text('রি-স্টার্ট',
+                    style: TextStyle(fontWeight: FontWeight.w900)),
+              ),
+            ),
+          ]),
+        ],
+      ),
+    );
+  }
+}
+
+class _MatchStatChip extends StatelessWidget {
+  const _MatchStatChip({required this.label, required this.value});
+  final String label;
+  final String value;
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+      decoration: BoxDecoration(
+        color: Colors.white.withValues(alpha: 0.08),
+        borderRadius: BorderRadius.circular(8),
+        border: Border.all(color: Colors.white.withValues(alpha: 0.14)),
+      ),
+      child: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Text(label,
+              style: TextStyle(
+                  color: Colors.white.withValues(alpha: 0.7),
+                  fontSize: 10,
+                  fontWeight: FontWeight.w800)),
+          const SizedBox(width: 4),
+          Text(value,
+              style: const TextStyle(
+                  color: Color(0xFFFFE000),
+                  fontWeight: FontWeight.w900,
+                  fontSize: 12)),
+        ],
+      ),
+    );
+  }
+}
+
+class _HeroBlitzGame extends StatefulWidget {
+  const _HeroBlitzGame({super.key});
+
+  @override
+  State<_HeroBlitzGame> createState() => _HeroBlitzGameState();
+}
+
+class _HeroBlitzGameState extends State<_HeroBlitzGame>
+    with TickerProviderStateMixin {
+  final _rng = math.Random();
+  final _tts = FlutterTts();
+  late ConfettiController _confetti;
+  late AnimationController _shakeCtrl;
+  static const _totalSeconds = 25;
+  static const _maxRounds = 8;
+  static const _sessionXpBonus = 50;
+
+  late _HeroNum _target;
+  late List<_HeroNum> _options;
+  Timer? _timer;
+  int _timeLeft = _totalSeconds;
+  int _score = 0;
+  int _streak = 0;
+  int _bestStreak = 0;
+  int _round = 1;
+  int _attempts = 0;
+  int _correct = 0;
+  final Map<int, int> _missed = {};
+  bool _locked = false;
+  int? _picked;
+  bool _slowMode = false;
+  bool _ttsReady = false;
+
+  @override
+  void initState() {
+    super.initState();
+    _confetti =
+        ConfettiController(duration: const Duration(milliseconds: 650));
+    _shakeCtrl =
+        AnimationController(vsync: this, duration: const Duration(milliseconds: 380));
+    _initTts();
+    _prepareRound(resetRoundCount: true);
+  }
+
+  Future<void> _initTts() async {
+    try {
+      await _tts.setLanguage('ja-JP');
+      await _tts.setSpeechRate(_slowMode ? 0.32 : 0.50);
+      await _tts.setPitch(1.05);
+      if (!mounted) return;
+      setState(() => _ttsReady = true);
+      WidgetsBinding.instance.addPostFrameCallback((_) => _speak());
+    } catch (_) {}
+  }
+
+  Future<void> _speak() async {
+    if (!_ttsReady) return;
+    await _tts.stop();
+    await _tts.setSpeechRate(_slowMode ? 0.32 : 0.50);
+    await _tts.speak(_target.kana);
+  }
+
+  void _prepareRound({bool resetRoundCount = false}) {
+    if (resetRoundCount) {
+      _round = 1;
+      _score = 0;
+      _streak = 0;
+      _bestStreak = 0;
+      _timeLeft = _totalSeconds;
+      _attempts = 0;
+      _correct = 0;
+      _missed.clear();
+    }
+    final t = _heroNumbers[_rng.nextInt(_heroNumbers.length)];
+    final pool =
+        _heroNumbers.where((e) => e.n != t.n).toList()..shuffle(_rng);
+    setState(() {
+      _target = t;
+      _options = [t, ...pool.take(3)]..shuffle(_rng);
+      _locked = false;
+      _picked = null;
+    });
+    if (_ttsReady) {
+      // ignore: discarded_futures
+      _speak();
+    }
+    if (resetRoundCount) {
+      _timer?.cancel();
+      _timer = Timer.periodic(const Duration(seconds: 1), (timer) {
+        if (!mounted) return;
+        if (_timeLeft <= 1) {
+          timer.cancel();
+          _showEndDialog();
+        } else {
+          setState(() => _timeLeft -= 1);
+        }
+      });
+    }
+  }
+
+  void _pick(_HeroNum n) {
+    if (_locked) return;
+    _completeRound(correct: n.n == _target.n, picked: n.n);
+  }
+
+  void _completeRound({required bool correct, int? picked}) {
+    if (_locked) return;
+    setState(() {
+      _locked = true;
+      _picked = picked;
+      _attempts += 1;
+      if (correct) {
+        _score += 10;
+        _streak += 1;
+        if (_streak > _bestStreak) _bestStreak = _streak;
+        _correct += 1;
+      } else {
+        _streak = 0;
+        _missed[_target.n] = (_missed[_target.n] ?? 0) + 1;
+      }
+    });
+    if (correct) {
+      HapticFeedback.mediumImpact();
+      _confetti.play();
+    } else {
+      HapticFeedback.heavyImpact();
+      _shakeCtrl.forward(from: 0);
+    }
+    Future.delayed(const Duration(milliseconds: 600), () {
+      if (!mounted) return;
+      if (_timeLeft <= 0 || _round >= _maxRounds) {
+        _showEndDialog();
+      } else {
+        _round += 1;
+        _prepareRound();
+      }
+    });
+  }
+
+  void _showEndDialog() {
+    _timer?.cancel();
+    final acc = _attempts == 0 ? 0 : ((_correct * 100) / _attempts).round();
+    _showAwesomeResult(
+      context: context,
+      title: 'স্পিড বস — রেজাল্ট',
+      scoreLabel: 'XP: ${_score + _sessionXpBonus}',
+      stats: [
+        'চেষ্টা: $_attempts',
+        'সঠিক: $_correct',
+        'নির্ভুলতা: $acc%',
+        'সেরা স্ট্রিক: $_bestStreak',
+        'সেশন বোনাস: +$_sessionXpBonus XP',
+      ],
+      missedLines: _missed.entries.toList()
+        ..sort((a, b) => b.value.compareTo(a.value)),
+      onPlayAgain: () => _prepareRound(resetRoundCount: true),
+    );
+  }
+
+  @override
+  void dispose() {
+    _timer?.cancel();
+    _confetti.dispose();
+    _shakeCtrl.dispose();
+    _tts.stop();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final progress = _round / _maxRounds;
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(16, 0, 16, 16),
+      child: Stack(
+        clipBehavior: Clip.none,
+        children: [
+          Align(
+            alignment: Alignment.topCenter,
+            child: IgnorePointer(
+              child: SizedBox(
+                height: 140,
+                width: double.infinity,
+                child: ConfettiWidget(
+                  confettiController: _confetti,
+                  blastDirectionality: BlastDirectionality.explosive,
+                  maxBlastForce: 14,
+                  minBlastForce: 6,
+                  emissionFrequency: 0.08,
+                  numberOfParticles: 12,
+                  gravity: 0.22,
+                  shouldLoop: false,
+                  colors: const [
+                    Color(0xFFFFE000),
+                    Color(0xFF10B981),
+                    Color(0xFFFF8A34),
+                    Color(0xFF3B82F6),
+                  ],
+                ),
+              ),
+            ),
+          ),
+          Column(
+            children: [
+              Container(
+                padding: const EdgeInsets.all(14),
+                decoration: _cardDeco(),
+                child: Column(
+                  children: [
+                    Row(
+                      children: [
+                        const Icon(Icons.flash_on_rounded,
+                            color: Color(0xFFFFE000)),
+                        const SizedBox(width: 8),
+                        Text('রাউন্ড: $_round/$_maxRounds',
+                            style: const TextStyle(
+                                color: Colors.white,
+                                fontWeight: FontWeight.w900)),
+                        const Spacer(),
+                        Text('স্কোর: $_score',
+                            style: const TextStyle(
+                                color: Colors.white,
+                                fontWeight: FontWeight.w900)),
+                      ],
+                    ),
+                    const SizedBox(height: 8),
+                    LinearProgressIndicator(
+                      minHeight: 8,
+                      borderRadius: BorderRadius.circular(99),
+                      value: progress.clamp(0, 1),
+                      backgroundColor: Colors.white.withValues(alpha: 0.12),
+                      valueColor:
+                          const AlwaysStoppedAnimation(Color(0xFFFFE000)),
+                    ),
+                  ],
+                ),
+              ),
+              const SizedBox(height: 10),
+              AnimatedBuilder(
+                animation: _shakeCtrl,
+                builder: (_, child) {
+                  final wrong = _picked != null && _picked != _target.n;
+                  final dx = wrong
+                      ? math.sin(_shakeCtrl.value * math.pi * 6) * 8
+                      : 0.0;
+                  return Transform.translate(
+                      offset: Offset(dx, 0), child: child);
+                },
+                child: Container(
+                  width: double.infinity,
+                  padding: const EdgeInsets.all(16),
+                  decoration: _cardDeco(),
+                  child: Column(
+                    children: [
+                      Row(
+                        children: [
+                          Expanded(
+                            child: Container(
+                              padding: const EdgeInsets.symmetric(
+                                  horizontal: 14, vertical: 12),
+                              decoration: BoxDecoration(
+                                gradient: LinearGradient(
+                                  begin: Alignment.topLeft,
+                                  end: Alignment.bottomRight,
+                                  colors: [
+                                    (_timeLeft <= 5
+                                            ? const Color(0xFFEF4444)
+                                            : const Color(0xFFFFE000))
+                                        .withValues(alpha: 0.22),
+                                    Colors.white.withValues(alpha: 0.06),
+                                  ],
+                                ),
+                                borderRadius: BorderRadius.circular(16),
+                                border: Border.all(
+                                  color: _timeLeft <= 5
+                                      ? const Color(0xFFFF6B6B)
+                                          .withValues(alpha: 0.9)
+                                      : const Color(0xFFFFE000)
+                                          .withValues(alpha: 0.85),
+                                  width: 2,
+                                ),
+                              ),
+                              child: Row(
+                                mainAxisAlignment: MainAxisAlignment.center,
+                                children: [
+                                  Icon(
+                                    Icons.timer_rounded,
+                                    color: _timeLeft <= 5
+                                        ? const Color(0xFFFF6B6B)
+                                        : const Color(0xFFFFE000),
+                                    size: 26,
+                                  ),
+                                  const SizedBox(width: 8),
+                                  Column(
+                                    crossAxisAlignment:
+                                        CrossAxisAlignment.start,
+                                    children: [
+                                      Text('মোট সময়',
+                                          style: TextStyle(
+                                              color: Colors.white
+                                                  .withValues(alpha: 0.78),
+                                              fontWeight: FontWeight.w800,
+                                              fontSize: 11)),
+                                      Text('$_timeLeft',
+                                          style: TextStyle(
+                                              color: _timeLeft <= 5
+                                                  ? const Color(0xFFFFB4B4)
+                                                  : const Color(0xFFFFE000),
+                                              fontWeight: FontWeight.w900,
+                                              fontSize: 32,
+                                              height: 1)),
+                                      Text('সেকেন্ড বাকি',
+                                          style: TextStyle(
+                                              color: Colors.white
+                                                  .withValues(alpha: 0.82),
+                                              fontWeight: FontWeight.w700,
+                                              fontSize: 12)),
+                                    ],
+                                  ),
+                                ],
+                              ),
+                            ),
+                          ),
+                          const SizedBox(width: 12),
+                          Column(
+                            mainAxisAlignment: MainAxisAlignment.center,
+                            children: [
+                              _BlitzStatChip(
+                                  label: 'স্ট্রিক', value: '$_streak'),
+                              const SizedBox(height: 6),
+                              _BlitzStatChip(
+                                  label: 'সেরা', value: '$_bestStreak'),
+                            ],
+                          ),
+                        ],
+                      ),
+                      const SizedBox(height: 14),
+                      Text(_target.kanji,
+                          style: const TextStyle(
+                              color: Colors.white,
+                              fontSize: 58,
+                              fontWeight: FontWeight.w900)),
+                      Text('${_target.kana} (${_target.bnPronunciation})',
+                          style: TextStyle(
+                              color: Colors.white.withValues(alpha: 0.86),
+                              fontWeight: FontWeight.w700)),
+                      const SizedBox(height: 10),
+                      Row(
+                        mainAxisAlignment: MainAxisAlignment.center,
+                        children: [
+                          GestureDetector(
+                            onTap: _speak,
+                            child: Container(
+                              padding: const EdgeInsets.symmetric(
+                                  horizontal: 14, vertical: 8),
+                              decoration: BoxDecoration(
+                                color: const Color(0xFFFFE000)
+                                    .withValues(alpha: 0.18),
+                                borderRadius: BorderRadius.circular(99),
+                                border: Border.all(
+                                    color: const Color(0xFFFFE000)
+                                        .withValues(alpha: 0.6)),
+                              ),
+                              child: const Row(
+                                mainAxisSize: MainAxisSize.min,
+                                children: [
+                                  Icon(Icons.volume_up_rounded,
+                                      color: Color(0xFFFFE000), size: 18),
+                                  SizedBox(width: 6),
+                                  Text('শুনি',
+                                      style: TextStyle(
+                                          color: Color(0xFFFFE000),
+                                          fontWeight: FontWeight.w900)),
+                                ],
+                              ),
+                            ),
+                          ),
+                          const SizedBox(width: 10),
+                          GestureDetector(
+                            onTap: () async {
+                              setState(() => _slowMode = !_slowMode);
+                              await _speak();
+                            },
+                            child: Container(
+                              padding: const EdgeInsets.symmetric(
+                                  horizontal: 14, vertical: 8),
+                              decoration: BoxDecoration(
+                                color: _slowMode
+                                    ? const Color(0xFFFFE000)
+                                    : Colors.white.withValues(alpha: 0.10),
+                                borderRadius: BorderRadius.circular(99),
+                                border: Border.all(
+                                    color:
+                                        Colors.white.withValues(alpha: 0.2)),
+                              ),
+                              child: Row(
+                                mainAxisSize: MainAxisSize.min,
+                                children: [
+                                  Icon(Icons.pets_rounded,
+                                      color: _slowMode
+                                          ? const Color(0xFF1E293B)
+                                          : Colors.white,
+                                      size: 18),
+                                  const SizedBox(width: 6),
+                                  Text('ধীরে',
+                                      style: TextStyle(
+                                          color: _slowMode
+                                              ? const Color(0xFF1E293B)
+                                              : Colors.white,
+                                          fontWeight: FontWeight.w900)),
+                                ],
+                              ),
+                            ),
+                          ),
+                        ],
+                      ),
+                      const SizedBox(height: 8),
+                      const Text('সঠিক বাংলা সংখ্যা বেছে নাও',
+                          style: TextStyle(
+                              color: Color(0xFFFFE000),
+                              fontWeight: FontWeight.w900)),
+                    ],
+                  ),
+                ),
+              ),
+              const SizedBox(height: 10),
+              Expanded(
+                child: GridView.builder(
+                  itemCount: _options.length,
+                  gridDelegate:
+                      const SliverGridDelegateWithFixedCrossAxisCount(
+                          crossAxisCount: 2,
+                          crossAxisSpacing: 10,
+                          mainAxisSpacing: 10,
+                          childAspectRatio: 1.7),
+                  itemBuilder: (_, i) {
+                    final o = _options[i];
+                    final picked = _picked == o.n;
+                    final correct = o.n == _target.n;
+                    final bg = _picked == null
+                        ? Colors.white.withValues(alpha: 0.06)
+                        : (correct
+                            ? const Color(0xFF10B981).withValues(alpha: 0.22)
+                            : (picked
+                                ? const Color(0xFFEF4444)
+                                    .withValues(alpha: 0.22)
+                                : Colors.white.withValues(alpha: 0.05)));
+                    final border = _picked == null
+                        ? Colors.white.withValues(alpha: 0.2)
+                        : (correct
+                            ? const Color(0xFF10B981)
+                            : (picked
+                                ? const Color(0xFFEF4444)
+                                : Colors.white.withValues(alpha: 0.18)));
+                    return GestureDetector(
+                      onTap: () => _pick(o),
+                      child: AnimatedScale(
+                        scale: picked && correct ? 1.05 : 1.0,
+                        duration: const Duration(milliseconds: 220),
+                        child: Container(
+                          decoration: BoxDecoration(
+                            color: bg,
+                            borderRadius: BorderRadius.circular(14),
+                            border: Border.all(
+                                color: border,
+                                width: _picked == null ? 1 : 2),
+                          ),
+                          child: Center(
+                            child: Text('${o.bnDigit} ${o.bnWord}',
+                                style: const TextStyle(
+                                    color: Colors.white,
+                                    fontWeight: FontWeight.w900,
+                                    fontSize: 20)),
+                          ),
+                        ),
+                      ),
+                    );
+                  },
+                ),
+              ),
+            ],
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _BlitzStatChip extends StatelessWidget {
+  const _BlitzStatChip({required this.label, required this.value});
+  final String label;
+  final String value;
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 6),
+      decoration: BoxDecoration(
+        color: Colors.white.withValues(alpha: 0.08),
+        borderRadius: BorderRadius.circular(10),
+        border: Border.all(color: Colors.white.withValues(alpha: 0.14)),
+      ),
+      child: Column(
+        children: [
+          Text(label,
+              style: TextStyle(
+                  color: Colors.white.withValues(alpha: 0.7),
+                  fontWeight: FontWeight.w800,
+                  fontSize: 10)),
+          Text(value,
+              style: const TextStyle(
+                  color: Color(0xFFFFE000),
+                  fontWeight: FontWeight.w900,
+                  fontSize: 16)),
+        ],
+      ),
+    );
+  }
+}
+
+/// শুনে যা বলেছে সেটার বাংলা বেছে নিন — শুধু ১–১০ জাপানি সংখ্যা।
+class _HeroTapWhatYouHearGame extends StatefulWidget {
+  const _HeroTapWhatYouHearGame({super.key});
+
+  @override
+  State<_HeroTapWhatYouHearGame> createState() => _HeroTapWhatYouHearGameState();
+}
+
+class _HeroTapWhatYouHearGameState extends State<_HeroTapWhatYouHearGame>
+    with TickerProviderStateMixin {
+  static const _totalRounds = 10;
+  static const _sessionXpBonus = 50;
+
+  final _rng = math.Random();
+  final _tts = FlutterTts();
+  late final Future<void> _ttsReady;
+  late ConfettiController _confetti;
+  late AnimationController _shakeCtrl;
+
+  late List<_HeroNum> _deck;
+  int _roundIdx = 0;
+  late _HeroNum _target;
+  late List<_HeroNum> _options;
+
+  bool _slowMode = false;
+  bool _locked = false;
+  int? _pickedN;
+  bool? _lastWasCorrect;
+  bool _showCorrectBanner = false;
+
+  final Stopwatch _sessionTimer = Stopwatch();
+  int _correct = 0;
+  int _totalAttempts = 0;
+  int _xp = 0;
+  int _bestStreak = 0;
+  int _streak = 0;
+  final Map<int, int> _missed = {};
+
+  @override
+  void initState() {
+    super.initState();
+    _confetti = ConfettiController(duration: const Duration(milliseconds: 650));
+    _shakeCtrl = AnimationController(vsync: this, duration: const Duration(milliseconds: 420));
+    _ttsReady = _initTts();
+    _newSession();
+  }
+
+  Future<void> _initTts() async {
+    await _tts.awaitSpeakCompletion(true);
+    await _tts.setLanguage('ja-JP');
+    await _tts.setSpeechRate(0.52);
+    await _tts.setPitch(1.05);
+    await _tts.setVolume(1.0);
+  }
+
+  Future<void> _applySpeechRate() async {
+    await _ttsReady;
+    await _tts.setSpeechRate(_slowMode ? 0.34 : 0.52);
+  }
+
+  void _newSession() {
+    _deck = List<_HeroNum>.of(_heroNumbers)..shuffle(_rng);
+    _roundIdx = 0;
+    _correct = 0;
+    _totalAttempts = 0;
+    _xp = 0;
+    _bestStreak = 0;
+    _streak = 0;
+    _missed.clear();
+    _sessionTimer
+      ..reset()
+      ..start();
+    _buildRound();
+    WidgetsBinding.instance.addPostFrameCallback((_) => _speakPrompt());
+  }
+
+  void _buildRound() {
+    _target = _deck[_roundIdx];
+    final pool = _heroNumbers.where((e) => e.n != _target.n).toList()..shuffle(_rng);
+    setState(() {
+      _options = [_target, ...pool.take(3)]..shuffle(_rng);
+      _locked = false;
+      _pickedN = null;
+      _lastWasCorrect = null;
+      _showCorrectBanner = false;
+    });
+  }
+
+  String _formatDuration(Duration d) {
+    final m = d.inMinutes.remainder(60).toString().padLeft(2, '0');
+    final s = d.inSeconds.remainder(60).toString().padLeft(2, '0');
+    return '$m:$s';
+  }
+
+  Future<void> _speakPrompt() async {
+    await _ttsReady;
+    await _tts.stop();
+    await _tts.speak('${_target.kana}。');
+  }
+
+  Future<void> _shake() async {
+    await _shakeCtrl.forward(from: 0);
+  }
+
+  void _pick(_HeroNum o) {
+    if (_locked) return;
+    _totalAttempts += 1;
+    final ok = o.n == _target.n;
+    setState(() {
+      _locked = true;
+      _pickedN = o.n;
+      _lastWasCorrect = ok;
+    });
+    if (ok) {
+      HapticFeedback.mediumImpact();
+      setState(() {
+        _correct += 1;
+        _streak += 1;
+        if (_streak > _bestStreak) _bestStreak = _streak;
+        _xp += 10;
+        _showCorrectBanner = true;
+      });
+      _confetti.play();
+      Future.delayed(const Duration(milliseconds: 1300), () {
+        if (!mounted) return;
+        setState(() {
+          _showCorrectBanner = false;
+          _pickedN = null;
+          _lastWasCorrect = null;
+          _locked = false;
+        });
+        if (_roundIdx >= _totalRounds - 1) {
+          _sessionTimer.stop();
+          _xp += _sessionXpBonus;
+          _showSessionEnd();
+        } else {
+          _roundIdx += 1;
+          _buildRound();
+          _speakPrompt();
+        }
+      });
+    } else {
+      HapticFeedback.heavyImpact();
+      setState(() {
+        _streak = 0;
+        _missed[_target.n] = (_missed[_target.n] ?? 0) + 1;
+      });
+      // ignore: discarded_futures
+      _shake();
+      Future.delayed(const Duration(milliseconds: 520), () {
+        if (!mounted) return;
+        setState(() {
+          _pickedN = null;
+          _lastWasCorrect = null;
+          _locked = false;
+        });
+      });
+    }
+  }
+
+  void _showSessionEnd() {
+    final acc = _totalAttempts == 0 ? 0 : ((_correct * 100) / _totalAttempts).round();
+    _showAwesomeResult(
+      context: context,
+      title: 'শুনে ট্যাপ — সেশন শেষ',
+      scoreLabel: 'মোট XP: $_xp',
+      stats: [
+        'সঠিক: $_correct/$_totalRounds',
+        'নির্ভুলতা: $acc%',
+        'সেশন বোনাস: +$_sessionXpBonus XP',
+        'সেরা স্ট্রিক: $_bestStreak',
+        'সময়: ${_formatDuration(_sessionTimer.elapsed)}',
+      ],
+      missedLines: _missed.entries.toList()..sort((a, b) => b.value.compareTo(a.value)),
+      onPlayAgain: _newSession,
+    );
+  }
+
+  @override
+  void dispose() {
+    _confetti.dispose();
+    _shakeCtrl.dispose();
+    _tts.stop();
+    super.dispose();
+  }
+
+  Widget _buildMcqTile(_HeroNum o, Color orange) {
+    final picked = _pickedN == o.n;
+    final isCorrect = o.n == _target.n;
+    final revealed = _pickedN != null;
+
+    Color border;
+    Color bg;
+    Color textColor = Colors.white;
+    if (!revealed) {
+      border = Colors.white.withValues(alpha: 0.18);
+      bg = Colors.white.withValues(alpha: 0.07);
+    } else if (isCorrect) {
+      border = const Color(0xFF10B981);
+      bg = const Color(0xFF10B981).withValues(alpha: 0.22);
+      textColor = const Color(0xFF10B981);
+    } else if (picked) {
+      border = const Color(0xFFEF4444);
+      bg = const Color(0xFFEF4444).withValues(alpha: 0.18);
+      textColor = const Color(0xFFEF4444);
+    } else {
+      border = Colors.white.withValues(alpha: 0.10);
+      bg = Colors.white.withValues(alpha: 0.04);
+    }
+
+    return Expanded(
+      child: Material(
+        color: Colors.transparent,
+        child: InkWell(
+          borderRadius: BorderRadius.circular(14),
+          onTap: _locked ? null : () => _pick(o),
+          child: Ink(
+            decoration: BoxDecoration(
+              color: bg,
+              borderRadius: BorderRadius.circular(14),
+              border: Border.all(
+                color: border,
+                width: (picked || (isCorrect && revealed)) ? 2.2 : 1.2,
+              ),
+            ),
+            child: Row(
+              mainAxisAlignment: MainAxisAlignment.center,
+              children: [
+                Text(
+                  o.bnDigit,
+                  style: TextStyle(
+                    color: textColor.withValues(alpha: 0.7),
+                    fontSize: 15,
+                    fontWeight: FontWeight.w700,
+                  ),
+                ),
+                const SizedBox(width: 6),
+                Text(
+                  o.bnWord,
+                  style: TextStyle(
+                    color: textColor,
+                    fontSize: 18,
+                    fontWeight: FontWeight.w900,
+                  ),
+                ),
+                if (revealed && isCorrect) ...[
+                  const SizedBox(width: 8),
+                  const Icon(Icons.check_circle_rounded,
+                      color: Color(0xFF10B981), size: 22),
+                ] else if (revealed && picked && !isCorrect) ...[
+                  const SizedBox(width: 8),
+                  const Icon(Icons.cancel_rounded,
+                      color: Color(0xFFEF4444), size: 22),
+                ],
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    const orange = Color(0xFFFF8A34);
+    final progress = (_roundIdx + 1) / _totalRounds;
+
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(16, 0, 16, 16),
+      child: Stack(
+        clipBehavior: Clip.none,
+        children: [
+          Align(
+            alignment: Alignment.topCenter,
+            child: IgnorePointer(
+              child: SizedBox(
+                height: 140,
+                width: double.infinity,
+                child: ConfettiWidget(
+                  confettiController: _confetti,
+                  blastDirectionality: BlastDirectionality.explosive,
+                  maxBlastForce: 16,
+                  minBlastForce: 6,
+                  emissionFrequency: 0.08,
+                  numberOfParticles: 14,
+                  gravity: 0.22,
+                  shouldLoop: false,
+                  colors: const [
+                    Color(0xFFFFE000),
+                    Color(0xFF10B981),
+                    Color(0xFFFF8A34),
+                    Color(0xFF3B82F6),
+                  ],
+                ),
+              ),
+            ),
+          ),
+          Column(
+            children: [
+              Container(
+                padding: const EdgeInsets.all(14),
+                decoration: BoxDecoration(
+                  color: const Color(0xFF1E293B),
+                  borderRadius: BorderRadius.circular(16),
+                  border: Border.all(color: orange.withValues(alpha: 0.45)),
+                  boxShadow: [
+                    BoxShadow(
+                      color: orange.withValues(alpha: 0.12),
+                      blurRadius: 18,
+                      offset: const Offset(0, 8),
+                    ),
+                  ],
+                ),
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.stretch,
+                  children: [
+                    Row(
+                      children: [
+                        const Icon(Icons.headphones_rounded, color: orange, size: 22),
+                        const SizedBox(width: 8),
+                        const Expanded(
+                          child: Text(
+                            'শুনে ট্যাপ — জাপানি বলা শুনে বাংলা বেছে নিন',
+                            style: TextStyle(
+                                color: Colors.white, fontWeight: FontWeight.w900, fontSize: 13),
+                          ),
+                        ),
+                        Text(
+                          _formatDuration(_sessionTimer.elapsed),
+                          style: TextStyle(
+                            color: Colors.white.withValues(alpha: 0.85),
+                            fontWeight: FontWeight.w900,
+                          ),
+                        ),
+                      ],
+                    ),
+                    const SizedBox(height: 10),
+                    LinearProgressIndicator(
+                      minHeight: 8,
+                      borderRadius: BorderRadius.circular(99),
+                      value: progress.clamp(0, 1),
+                      backgroundColor: Colors.white.withValues(alpha: 0.12),
+                      valueColor: const AlwaysStoppedAnimation(orange),
+                    ),
+                    const SizedBox(height: 8),
+                    Row(
+                      children: [
+                        Text(
+                          'রাউন্ড ${_roundIdx + 1}/$_totalRounds',
+                          style: TextStyle(
+                              color: Colors.white.withValues(alpha: 0.82), fontWeight: FontWeight.w800),
+                        ),
+                        const Spacer(),
+                        Text('XP: $_xp',
+                            style: const TextStyle(color: Color(0xFFFFE000), fontWeight: FontWeight.w900)),
+                        const SizedBox(width: 10),
+                        Text('স্ট্রিক: $_streak',
+                            style: TextStyle(
+                                color: Colors.white.withValues(alpha: 0.82), fontWeight: FontWeight.w800)),
+                      ],
+                    ),
+                    const SizedBox(height: 6),
+                    Text(
+                      'নির্ভুলতা: ${_totalAttempts == 0 ? 0 : ((_correct * 100) / _totalAttempts).round()}%',
+                      style: TextStyle(
+                          color: Colors.white.withValues(alpha: 0.75), fontWeight: FontWeight.w700, fontSize: 12),
+                    ),
+                  ],
+                ),
+              ),
+              const SizedBox(height: 12),
+              // ── Number card ──────────────────────────────────────────
+              AnimatedBuilder(
+                animation: _shakeCtrl,
+                builder: (context, child) {
+                  final t = _shakeCtrl.value;
+                  final dx = math.sin(t * math.pi * 6) * 10 * (1 - t);
+                  return Transform.translate(offset: Offset(dx, 0), child: child);
+                },
+                child: Container(
+                  width: double.infinity,
+                  padding: const EdgeInsets.fromLTRB(20, 22, 20, 18),
+                  decoration: BoxDecoration(
+                    color: const Color(0xFF1E293B),
+                    borderRadius: BorderRadius.circular(20),
+                    border: Border.all(color: orange.withValues(alpha: 0.55), width: 2),
+                    boxShadow: [
+                      BoxShadow(
+                        color: orange.withValues(alpha: 0.18),
+                        blurRadius: 24,
+                        offset: const Offset(0, 8),
+                      ),
+                    ],
+                  ),
+                  child: Column(
+                    children: [
+                      Text(
+                        _target.kanji,
+                        style: const TextStyle(
+                          color: Colors.white,
+                          fontSize: 76,
+                          fontWeight: FontWeight.w900,
+                          height: 1.0,
+                        ),
+                      ),
+                      const SizedBox(height: 6),
+                      Text(
+                        _target.kana,
+                        style: TextStyle(
+                          color: Colors.white.withValues(alpha: 0.88),
+                          fontSize: 28,
+                          fontWeight: FontWeight.w800,
+                        ),
+                      ),
+                      const SizedBox(height: 8),
+                      Container(
+                        padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 6),
+                        decoration: BoxDecoration(
+                          color: orange.withValues(alpha: 0.15),
+                          borderRadius: BorderRadius.circular(20),
+                        ),
+                        child: Text(
+                          _target.bnPronunciation,
+                          style: const TextStyle(
+                            color: Color(0xFFFFE000),
+                            fontSize: 18,
+                            fontWeight: FontWeight.w900,
+                          ),
+                        ),
+                      ),
+                      const SizedBox(height: 16),
+                      Row(
+                        children: [
+                          Expanded(
+                            child: ElevatedButton.icon(
+                              onPressed: _locked ? null : _speakPrompt,
+                              style: ElevatedButton.styleFrom(
+                                backgroundColor: orange,
+                                foregroundColor: Colors.white,
+                                padding: const EdgeInsets.symmetric(vertical: 12),
+                                shape: RoundedRectangleBorder(
+                                    borderRadius: BorderRadius.circular(12)),
+                              ),
+                              icon: const Icon(Icons.volume_up_rounded),
+                              label: const Text('আবার শুনুন',
+                                  style: TextStyle(fontWeight: FontWeight.w900)),
+                            ),
+                          ),
+                          const SizedBox(width: 10),
+                          Expanded(
+                            child: OutlinedButton.icon(
+                              onPressed: _locked
+                                  ? null
+                                  : () async {
+                                      setState(() => _slowMode = !_slowMode);
+                                      await _applySpeechRate();
+                                      if (mounted) setState(() {});
+                                      await _speakPrompt();
+                                    },
+                              style: OutlinedButton.styleFrom(
+                                foregroundColor: _slowMode ? orange : Colors.white,
+                                side: BorderSide(
+                                    color: _slowMode
+                                        ? orange
+                                        : Colors.white.withValues(alpha: 0.28)),
+                                padding: const EdgeInsets.symmetric(vertical: 12),
+                                shape: RoundedRectangleBorder(
+                                    borderRadius: BorderRadius.circular(12)),
+                              ),
+                              icon: Icon(_slowMode
+                                  ? Icons.speed_rounded
+                                  : Icons.hourglass_bottom_rounded),
+                              label: Text(_slowMode ? 'স্বাভাবিক' : 'ধীর শোনা',
+                                  style: const TextStyle(fontWeight: FontWeight.w900)),
+                            ),
+                          ),
+                        ],
+                      ),
+                    ],
+                  ),
+                ),
+              ),
+              const SizedBox(height: 16),
+              // ── MCQ ──────────────────────────────────────────────────
+              const Text(
+                'এইবার আপনি বলেন সঠিক উত্তর কোনটি?',
+                style: TextStyle(
+                  color: Colors.white,
+                  fontSize: 14,
+                  fontWeight: FontWeight.w900,
+                ),
+              ),
+              const SizedBox(height: 10),
+              Expanded(
+                child: Column(
+                  children: [
+                    for (int _i = 0; _i < _options.length; _i++) ...[
+                      if (_i != 0) const SizedBox(height: 10),
+                      _buildMcqTile(_options[_i], orange),
+                    ],
+                  ],
+                ),
+              ),
+            ],
+          ),
+          Positioned(
+            left: 0,
+            right: 0,
+            bottom: 0,
+            child: AnimatedSlide(
+              duration: const Duration(milliseconds: 360),
+              curve: Curves.easeOutCubic,
+              offset: _showCorrectBanner ? Offset.zero : const Offset(0, 1.2),
+              child: AnimatedOpacity(
+                duration: const Duration(milliseconds: 220),
+                opacity: _showCorrectBanner ? 1 : 0,
+                child: IgnorePointer(
+                  ignoring: !_showCorrectBanner,
+                  child: Container(
+                    margin: const EdgeInsets.only(bottom: 6),
+                    padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 14),
+                    decoration: BoxDecoration(
+                      color: const Color(0xFF10B981),
+                      borderRadius: BorderRadius.circular(16),
+                      boxShadow: [
+                        BoxShadow(
+                          color: Colors.black.withValues(alpha: 0.35),
+                          blurRadius: 18,
+                          offset: const Offset(0, 8),
+                        ),
+                      ],
+                    ),
+                    child: Column(
+                      mainAxisSize: MainAxisSize.min,
+                      crossAxisAlignment: CrossAxisAlignment.stretch,
+                      children: [
+                        Row(
+                          children: [
+                            const Icon(Icons.thumb_up_alt_rounded, color: Colors.white, size: 26),
+                            const SizedBox(width: 10),
+                            const Text(
+                              'সঠিক!',
+                              style: TextStyle(
+                                  color: Colors.white, fontWeight: FontWeight.w900, fontSize: 22),
+                            ),
+                            const Spacer(),
+                            Row(
+                              children: List.generate(
+                                5,
+                                (i) => Padding(
+                                  padding: const EdgeInsets.only(left: 2),
+                                  child: Icon(
+                                    Icons.star_rounded,
+                                    color: i < math.min(5, _streak)
+                                        ? const Color(0xFFFFE000)
+                                        : Colors.white.withValues(alpha: 0.22),
+                                    size: 22,
+                                  ),
+                                ),
+                              ),
+                            ),
+                          ],
+                        ),
+                        const SizedBox(height: 6),
+                        Text(
+                          '${_target.kana} (${_target.kanji}) → ${_target.bnDigit} ${_target.bnWord}',
+                          textAlign: TextAlign.center,
+                          style: const TextStyle(
+                            color: Colors.white,
+                            fontWeight: FontWeight.w800,
+                            fontSize: 16,
+                          ),
+                        ),
+                      ],
+                    ),
+                  ),
+                ),
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+// ═════════════════════════════════════════════════════════════════════
+// পড়া মাস্টার — Reading game with 3 question modes
+// Mode A: BN digit → JP pronunciation (BN options)
+// Mode B: BN word  → JP pronunciation (BN options)
+// Mode C: JP pronunciation → BN word + digit
+// ═════════════════════════════════════════════════════════════════════
+
+enum _ReadMode { bnDigitToJp, bnWordToJp, jpToBn }
+
+class _HeroReadGame extends StatefulWidget {
+  const _HeroReadGame({super.key});
+
+  @override
+  State<_HeroReadGame> createState() => _HeroReadGameState();
+}
+
+class _HeroReadGameState extends State<_HeroReadGame>
+    with TickerProviderStateMixin {
+  static const _totalRounds = 10;
+  static const _sessionXpBonus = 50;
+  static const _violet = Color(0xFF8B5CF6);
+  static const _violetDark = Color(0xFF6D28D9);
+
+  final _rng = math.Random();
+  final _tts = FlutterTts();
+  late final Future<void> _ttsReady;
+  late ConfettiController _confetti;
+  late AnimationController _shakeCtrl;
+  late AnimationController _cardCtrl;
+
+  late List<_HeroNum> _deck;
+  int _roundIdx = 0;
+  late _HeroNum _target;
+  late List<_HeroNum> _options;
+  late _ReadMode _mode;
+
+  bool _locked = false;
+  int? _pickedN;
+  bool? _lastWasCorrect;
+  bool _showCorrectBanner = false;
+  bool _revealed = false;
+
+  final Stopwatch _sessionTimer = Stopwatch();
+  int _correct = 0;
+  int _totalAttempts = 0;
+  int _xp = 0;
+  int _bestStreak = 0;
+  int _streak = 0;
+  final Map<int, int> _missed = {};
+
+  @override
+  void initState() {
+    super.initState();
+    _confetti = ConfettiController(duration: const Duration(milliseconds: 700));
+    _shakeCtrl = AnimationController(
+        vsync: this, duration: const Duration(milliseconds: 420));
+    _cardCtrl = AnimationController(
+        vsync: this, duration: const Duration(milliseconds: 360));
+    _ttsReady = _initTts();
+    _newSession();
+  }
+
+  Future<void> _initTts() async {
+    await _tts.awaitSpeakCompletion(true);
+    await _tts.setLanguage('ja-JP');
+    await _tts.setSpeechRate(0.48);
+    await _tts.setPitch(1.05);
+    await _tts.setVolume(1.0);
+  }
+
+  Future<void> _speakTarget() async {
+    await _ttsReady;
+    await _tts.stop();
+    await _tts.speak('${_target.kana}。');
+  }
+
+  void _newSession() {
+    _deck = List<_HeroNum>.of(_heroNumbers)..shuffle(_rng);
+    _roundIdx = 0;
+    _correct = 0;
+    _totalAttempts = 0;
+    _xp = 0;
+    _bestStreak = 0;
+    _streak = 0;
+    _missed.clear();
+    _sessionTimer
+      ..reset()
+      ..start();
+    _buildRound();
+  }
+
+  void _buildRound() {
+    _target = _deck[_roundIdx];
+    // Strict alternation: even rounds = BN→JP, odd rounds = JP→BN.
+    // Within BN→JP, alternate between digit and word for variety.
+    if (_roundIdx.isEven) {
+      _mode = (_roundIdx ~/ 2).isEven
+          ? _ReadMode.bnDigitToJp
+          : _ReadMode.bnWordToJp;
+    } else {
+      _mode = _ReadMode.jpToBn;
+    }
+    final pool = _heroNumbers.where((e) => e.n != _target.n).toList()
+      ..shuffle(_rng);
+    setState(() {
+      _options = [_target, ...pool.take(3)]..shuffle(_rng);
+      _locked = false;
+      _pickedN = null;
+      _lastWasCorrect = null;
+      _showCorrectBanner = false;
+      _revealed = false;
+    });
+    _cardCtrl.forward(from: 0);
+  }
+
+  String _formatDuration(Duration d) {
+    final m = d.inMinutes.remainder(60).toString().padLeft(2, '0');
+    final s = d.inSeconds.remainder(60).toString().padLeft(2, '0');
+    return '$m:$s';
+  }
+
+  void _pick(_HeroNum o) {
+    if (_locked) return;
+    _totalAttempts += 1;
+    final ok = o.n == _target.n;
+    setState(() {
+      _locked = true;
+      _pickedN = o.n;
+      _lastWasCorrect = ok;
+      _revealed = true;
+    });
+    if (ok) {
+      HapticFeedback.mediumImpact();
+      setState(() {
+        _correct += 1;
+        _streak += 1;
+        if (_streak > _bestStreak) _bestStreak = _streak;
+        _xp += 10;
+        _showCorrectBanner = true;
+      });
+      _confetti.play();
+      // ignore: discarded_futures
+      _speakTarget();
+      Future.delayed(const Duration(milliseconds: 1400), () {
+        if (!mounted) return;
+        setState(() {
+          _showCorrectBanner = false;
+          _pickedN = null;
+          _lastWasCorrect = null;
+          _locked = false;
+        });
+        if (_roundIdx >= _totalRounds - 1) {
+          _sessionTimer.stop();
+          _xp += _sessionXpBonus;
+          _showSessionEnd();
+        } else {
+          _roundIdx += 1;
+          _buildRound();
+        }
+      });
+    } else {
+      HapticFeedback.heavyImpact();
+      setState(() {
+        _streak = 0;
+        _missed[_target.n] = (_missed[_target.n] ?? 0) + 1;
+      });
+      _shakeCtrl.forward(from: 0);
+      // brief flash, then unlock so the user can try again or continue
+      Future.delayed(const Duration(milliseconds: 900), () {
+        if (!mounted) return;
+        setState(() {
+          _pickedN = null;
+          _lastWasCorrect = null;
+          _locked = false;
+          _revealed = false;
+        });
+      });
+    }
+  }
+
+  void _showSessionEnd() {
+    final acc = _totalAttempts == 0
+        ? 0
+        : ((_correct * 100) / _totalAttempts).round();
+    _showAwesomeResult(
+      context: context,
+      title: 'পড়া মাস্টার — সেশন শেষ',
+      scoreLabel: 'মোট XP: $_xp',
+      stats: [
+        'সঠিক: $_correct/$_totalRounds',
+        'নির্ভুলতা: $acc%',
+        'সেশন বোনাস: +$_sessionXpBonus XP',
+        'সেরা স্ট্রিক: $_bestStreak',
+        'সময়: ${_formatDuration(_sessionTimer.elapsed)}',
+      ],
+      missedLines: _missed.entries.toList()
+        ..sort((a, b) => b.value.compareTo(a.value)),
+      onPlayAgain: _newSession,
+    );
+  }
+
+  @override
+  void dispose() {
+    _confetti.dispose();
+    _shakeCtrl.dispose();
+    _cardCtrl.dispose();
+    _tts.stop();
+    super.dispose();
+  }
+
+  // ─── Mode-aware getters ─────────────────────────────────────────────
+  String get _modeBadge => switch (_mode) {
+        _ReadMode.bnDigitToJp => 'BN → JP',
+        _ReadMode.bnWordToJp => 'BN → JP',
+        _ReadMode.jpToBn => 'JP → BN',
+      };
+
+  String get _questionText => switch (_mode) {
+        _ReadMode.bnDigitToJp =>
+          'এটি জাপানিতে কী বলব? — সঠিক উত্তর কোনটি?',
+        _ReadMode.bnWordToJp =>
+          'এটি জাপানিতে কী বলব? — সঠিক উত্তর কোনটি?',
+        _ReadMode.jpToBn => 'এটি বাংলায় কী? — সঠিক উত্তর কোনটি?',
+      };
+
+  bool get _isJpToBn => _mode == _ReadMode.jpToBn;
+
+  @override
+  Widget build(BuildContext context) {
+    final progress = (_roundIdx + 1) / _totalRounds;
+
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(16, 0, 16, 16),
+      child: Stack(
+        clipBehavior: Clip.none,
+        children: [
+          Align(
+            alignment: Alignment.topCenter,
+            child: IgnorePointer(
+              child: SizedBox(
+                height: 140,
+                width: double.infinity,
+                child: ConfettiWidget(
+                  confettiController: _confetti,
+                  blastDirectionality: BlastDirectionality.explosive,
+                  maxBlastForce: 16,
+                  minBlastForce: 6,
+                  emissionFrequency: 0.08,
+                  numberOfParticles: 14,
+                  gravity: 0.22,
+                  shouldLoop: false,
+                  colors: const [
+                    Color(0xFFFFE000),
+                    Color(0xFF10B981),
+                    _violet,
+                    Color(0xFF3B82F6),
+                  ],
+                ),
+              ),
+            ),
+          ),
+          Column(
+            children: [
+              // ── Header panel ───────────────────────────────────────
+              Container(
+                padding: const EdgeInsets.all(14),
+                decoration: BoxDecoration(
+                  color: const Color(0xFF1E293B),
+                  borderRadius: BorderRadius.circular(16),
+                  border: Border.all(color: _violet.withValues(alpha: 0.45)),
+                  boxShadow: [
+                    BoxShadow(
+                      color: _violet.withValues(alpha: 0.12),
+                      blurRadius: 18,
+                      offset: const Offset(0, 8),
+                    ),
+                  ],
+                ),
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.stretch,
+                  children: [
+                    Row(
+                      children: [
+                        const Icon(Icons.menu_book_rounded,
+                            color: _violet, size: 22),
+                        const SizedBox(width: 8),
+                        const Expanded(
+                          child: Text(
+                            'পড়া মাস্টার — পড়ে বুঝে সঠিক উত্তর বাছুন',
+                            style: TextStyle(
+                                color: Colors.white,
+                                fontWeight: FontWeight.w900,
+                                fontSize: 13),
+                          ),
+                        ),
+                        Text(
+                          _formatDuration(_sessionTimer.elapsed),
+                          style: TextStyle(
+                            color: Colors.white.withValues(alpha: 0.85),
+                            fontWeight: FontWeight.w900,
+                          ),
+                        ),
+                      ],
+                    ),
+                    const SizedBox(height: 10),
+                    LinearProgressIndicator(
+                      minHeight: 8,
+                      borderRadius: BorderRadius.circular(99),
+                      value: progress.clamp(0, 1),
+                      backgroundColor: Colors.white.withValues(alpha: 0.12),
+                      valueColor: const AlwaysStoppedAnimation(_violet),
+                    ),
+                    const SizedBox(height: 8),
+                    Row(
+                      children: [
+                        Text(
+                          'রাউন্ড ${_roundIdx + 1}/$_totalRounds',
+                          style: TextStyle(
+                              color: Colors.white.withValues(alpha: 0.82),
+                              fontWeight: FontWeight.w800),
+                        ),
+                        const Spacer(),
+                        Text('XP: $_xp',
+                            style: const TextStyle(
+                                color: Color(0xFFFFE000),
+                                fontWeight: FontWeight.w900)),
+                        const SizedBox(width: 10),
+                        Text('স্ট্রিক: $_streak',
+                            style: TextStyle(
+                                color: Colors.white.withValues(alpha: 0.82),
+                                fontWeight: FontWeight.w800)),
+                      ],
+                    ),
+                  ],
+                ),
+              ),
+              const SizedBox(height: 12),
+
+              // ── Prompt card with mode-aware content ────────────────
+              AnimatedBuilder(
+                animation: _shakeCtrl,
+                builder: (context, child) {
+                  final t = _shakeCtrl.value;
+                  final dx = math.sin(t * math.pi * 6) * 10 * (1 - t);
+                  return Transform.translate(
+                      offset: Offset(dx, 0), child: child);
+                },
+                child: ScaleTransition(
+                  scale: Tween<double>(begin: 0.94, end: 1.0).animate(
+                      CurvedAnimation(parent: _cardCtrl, curve: Curves.easeOutBack)),
+                  child: Container(
+                    width: double.infinity,
+                    padding: const EdgeInsets.fromLTRB(20, 18, 20, 20),
+                    decoration: BoxDecoration(
+                      gradient: const LinearGradient(
+                        colors: [Color(0xFF1E293B), Color(0xFF111827)],
+                        begin: Alignment.topLeft,
+                        end: Alignment.bottomRight,
+                      ),
+                      borderRadius: BorderRadius.circular(20),
+                      border: Border.all(
+                          color: _violet.withValues(alpha: 0.55), width: 2),
+                      boxShadow: [
+                        BoxShadow(
+                          color: _violet.withValues(alpha: 0.22),
+                          blurRadius: 26,
+                          offset: const Offset(0, 10),
+                        ),
+                      ],
+                    ),
+                    child: Column(
+                      children: [
+                        // Mode badge
+                        Container(
+                          padding: const EdgeInsets.symmetric(
+                              horizontal: 12, vertical: 4),
+                          decoration: BoxDecoration(
+                            gradient: const LinearGradient(
+                              colors: [_violet, _violetDark],
+                            ),
+                            borderRadius: BorderRadius.circular(99),
+                          ),
+                          child: Text(
+                            _modeBadge,
+                            style: const TextStyle(
+                              color: Colors.white,
+                              fontSize: 11,
+                              fontWeight: FontWeight.w900,
+                              letterSpacing: 1.2,
+                            ),
+                          ),
+                        ),
+                        const SizedBox(height: 10),
+                        Text(
+                          _isJpToBn ? 'জাপানি উচ্চারণ পড়ুন' : 'বাংলা পড়ুন',
+                          style: TextStyle(
+                            color: Colors.white.withValues(alpha: 0.6),
+                            fontSize: 12,
+                            fontWeight: FontWeight.w700,
+                          ),
+                        ),
+                        const SizedBox(height: 8),
+                        _buildPromptBody(),
+                        if (_revealed && _lastWasCorrect == true) ...[
+                          const SizedBox(height: 14),
+                          _buildAnswerReveal(),
+                        ],
+                      ],
+                    ),
+                  ),
+                ),
+              ),
+
+              const SizedBox(height: 14),
+              // ── Question line ──────────────────────────────────────
+              Text(
+                _questionText,
+                style: const TextStyle(
+                  color: Colors.white,
+                  fontSize: 14,
+                  fontWeight: FontWeight.w900,
+                ),
+              ),
+              const SizedBox(height: 10),
+
+              // ── Options ────────────────────────────────────────────
+              Expanded(
+                child: Column(
+                  children: [
+                    for (int _i = 0; _i < _options.length; _i++) ...[
+                      if (_i != 0) const SizedBox(height: 10),
+                      _buildOptionTile(_options[_i]),
+                    ],
+                  ],
+                ),
+              ),
+            ],
+          ),
+
+          // ── Correct banner ───────────────────────────────────────
+          Positioned(
+            left: 0,
+            right: 0,
+            bottom: 0,
+            child: AnimatedSlide(
+              duration: const Duration(milliseconds: 360),
+              curve: Curves.easeOutCubic,
+              offset: _showCorrectBanner ? Offset.zero : const Offset(0, 1.2),
+              child: AnimatedOpacity(
+                duration: const Duration(milliseconds: 220),
+                opacity: _showCorrectBanner ? 1 : 0,
+                child: IgnorePointer(
+                  ignoring: !_showCorrectBanner,
+                  child: Container(
+                    margin: const EdgeInsets.only(bottom: 6),
+                    padding: const EdgeInsets.symmetric(
+                        horizontal: 16, vertical: 14),
+                    decoration: BoxDecoration(
+                      color: const Color(0xFF10B981),
+                      borderRadius: BorderRadius.circular(16),
+                      boxShadow: [
+                        BoxShadow(
+                          color: Colors.black.withValues(alpha: 0.35),
+                          blurRadius: 18,
+                          offset: const Offset(0, 8),
+                        ),
+                      ],
+                    ),
+                    child: Column(
+                      mainAxisSize: MainAxisSize.min,
+                      crossAxisAlignment: CrossAxisAlignment.stretch,
+                      children: [
+                        Row(
+                          children: [
+                            const Icon(Icons.thumb_up_alt_rounded,
+                                color: Colors.white, size: 26),
+                            const SizedBox(width: 10),
+                            const Text(
+                              'সঠিক!',
+                              style: TextStyle(
+                                  color: Colors.white,
+                                  fontWeight: FontWeight.w900,
+                                  fontSize: 22),
+                            ),
+                            const Spacer(),
+                            Row(
+                              children: List.generate(
+                                5,
+                                (i) => Padding(
+                                  padding: const EdgeInsets.only(left: 2),
+                                  child: Icon(
+                                    Icons.star_rounded,
+                                    color: i < math.min(5, _streak)
+                                        ? const Color(0xFFFFE000)
+                                        : Colors.white.withValues(alpha: 0.22),
+                                    size: 22,
+                                  ),
+                                ),
+                              ),
+                            ),
+                          ],
+                        ),
+                        const SizedBox(height: 6),
+                        Text(
+                          '${_target.kanji} ${_target.kana} (${_target.bnPronunciation}) → ${_target.bnDigit} ${_target.bnWord}',
+                          textAlign: TextAlign.center,
+                          style: const TextStyle(
+                            color: Colors.white,
+                            fontWeight: FontWeight.w800,
+                            fontSize: 15,
+                          ),
+                        ),
+                      ],
+                    ),
+                  ),
+                ),
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildPromptBody() {
+    switch (_mode) {
+      case _ReadMode.bnDigitToJp:
+        return Text(
+          _target.bnDigit,
+          style: const TextStyle(
+            color: Colors.white,
+            fontSize: 84,
+            fontWeight: FontWeight.w900,
+            height: 1.0,
+          ),
+        );
+      case _ReadMode.bnWordToJp:
+        return Text(
+          _target.bnWord,
+          style: const TextStyle(
+            color: Colors.white,
+            fontSize: 56,
+            fontWeight: FontWeight.w900,
+            height: 1.05,
+          ),
+        );
+      case _ReadMode.jpToBn:
+        return Text(
+          _target.bnPronunciation,
+          style: const TextStyle(
+            color: Color(0xFFFFE000),
+            fontSize: 56,
+            fontWeight: FontWeight.w900,
+            height: 1.05,
+          ),
+        );
+    }
+  }
+
+  Widget _buildAnswerReveal() {
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 10),
+      decoration: BoxDecoration(
+        color: Colors.white.withValues(alpha: 0.06),
+        borderRadius: BorderRadius.circular(12),
+        border: Border.all(color: Colors.white.withValues(alpha: 0.12)),
+      ),
+      child: Row(
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: [
+          Text(
+            _target.kanji,
+            style: const TextStyle(
+              color: Colors.white,
+              fontSize: 24,
+              fontWeight: FontWeight.w900,
+            ),
+          ),
+          const SizedBox(width: 8),
+          Text(
+            _target.kana,
+            style: TextStyle(
+              color: Colors.white.withValues(alpha: 0.85),
+              fontSize: 18,
+              fontWeight: FontWeight.w800,
+            ),
+          ),
+          const SizedBox(width: 8),
+          Text(
+            '· ${_target.bnDigit} ${_target.bnWord}',
+            style: const TextStyle(
+              color: Color(0xFF10B981),
+              fontSize: 14,
+              fontWeight: FontWeight.w900,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildOptionTile(_HeroNum o) {
+    final picked = _pickedN == o.n;
+    final isCorrect = o.n == _target.n;
+    final revealed = _pickedN != null;
+
+    Color border;
+    Color bg;
+    Color textColor = Colors.white;
+    if (!revealed) {
+      border = Colors.white.withValues(alpha: 0.18);
+      bg = Colors.white.withValues(alpha: 0.07);
+    } else if (isCorrect) {
+      border = const Color(0xFF10B981);
+      bg = const Color(0xFF10B981).withValues(alpha: 0.22);
+      textColor = const Color(0xFF10B981);
+    } else if (picked) {
+      border = const Color(0xFFEF4444);
+      bg = const Color(0xFFEF4444).withValues(alpha: 0.18);
+      textColor = const Color(0xFFEF4444);
+    } else {
+      border = Colors.white.withValues(alpha: 0.10);
+      bg = Colors.white.withValues(alpha: 0.04);
+    }
+
+    // Option label depends on mode
+    final String optionLabel;
+    if (_isJpToBn) {
+      optionLabel = '${o.bnDigit}  ${o.bnWord}';
+    } else {
+      optionLabel = o.bnPronunciation;
+    }
+
+    return Expanded(
+      child: Material(
+        color: Colors.transparent,
+        child: InkWell(
+          borderRadius: BorderRadius.circular(14),
+          onTap: _locked ? null : () => _pick(o),
+          child: Ink(
+            decoration: BoxDecoration(
+              color: bg,
+              borderRadius: BorderRadius.circular(14),
+              border: Border.all(
+                color: border,
+                width: (picked || (isCorrect && revealed)) ? 2.4 : 1.2,
+              ),
+            ),
+            child: Row(
+              mainAxisAlignment: MainAxisAlignment.center,
+              children: [
+                Text(
+                  optionLabel,
+                  style: TextStyle(
+                    color: textColor,
+                    fontSize: 19,
+                    fontWeight: FontWeight.w900,
+                  ),
+                ),
+                if (revealed && isCorrect) ...[
+                  const SizedBox(width: 10),
+                  const Icon(Icons.check_circle_rounded,
+                      color: Color(0xFF10B981), size: 22),
+                ] else if (revealed && picked && !isCorrect) ...[
+                  const SizedBox(width: 10),
+                  const Icon(Icons.cancel_rounded,
+                      color: Color(0xFFEF4444), size: 22),
+                ],
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+// ═════════════════════════════════════════════════════════════════════
+// সাজাও — Ordering game: drag JP pronunciations to BN positions 1..10
+// ═════════════════════════════════════════════════════════════════════
+
+class _HeroOrderGame extends StatefulWidget {
+  const _HeroOrderGame({super.key});
+
+  @override
+  State<_HeroOrderGame> createState() => _HeroOrderGameState();
+}
+
+class _HeroOrderGameState extends State<_HeroOrderGame>
+    with TickerProviderStateMixin {
+  static const _teal = Color(0xFF14B8A6);
+  static const _tealDark = Color(0xFF0F766E);
+  static const _sessionXpBonus = 50;
+
+  final _rng = math.Random();
+  late ConfettiController _confetti;
+  late AnimationController _shakeCtrl;
+  int? _shakeSlot;
+
+  // Slot number (1..10) → placed item (null if empty).
+  final Map<int, _HeroNum?> _placed = {};
+  // Remaining draggable chips, shuffled.
+  late List<_HeroNum> _pool;
+
+  final Stopwatch _sessionTimer = Stopwatch();
+  int _correct = 0;
+  int _wrongAttempts = 0;
+  int _xp = 0;
+  int _streak = 0;
+  int _bestStreak = 0;
+  final Map<int, int> _missed = {};
+
+  @override
+  void initState() {
+    super.initState();
+    _confetti = ConfettiController(duration: const Duration(milliseconds: 850));
+    _shakeCtrl = AnimationController(
+        vsync: this, duration: const Duration(milliseconds: 380));
+    _newSession();
+  }
+
+  @override
+  void dispose() {
+    _confetti.dispose();
+    _shakeCtrl.dispose();
+    super.dispose();
+  }
+
+  void _newSession() {
+    _placed
+      ..clear()
+      ..addEntries(_heroNumbers.map((h) => MapEntry(h.n, null)));
+    _pool = List<_HeroNum>.of(_heroNumbers)..shuffle(_rng);
+    _correct = 0;
+    _wrongAttempts = 0;
+    _xp = 0;
+    _streak = 0;
+    _bestStreak = 0;
+    _missed.clear();
+    _sessionTimer
+      ..reset()
+      ..start();
+    setState(() {});
+  }
+
+  String _formatDuration(Duration d) {
+    final m = d.inMinutes.remainder(60).toString().padLeft(2, '0');
+    final s = d.inSeconds.remainder(60).toString().padLeft(2, '0');
+    return '$m:$s';
+  }
+
+  void _onDrop(int slotN, _HeroNum chip) {
+    if (_placed[slotN] != null) return;
+    final ok = chip.n == slotN;
+    if (ok) {
+      HapticFeedback.mediumImpact();
+      setState(() {
+        _placed[slotN] = chip;
+        _pool.remove(chip);
+        _correct += 1;
+        _streak += 1;
+        if (_streak > _bestStreak) _bestStreak = _streak;
+        _xp += 10;
+      });
+      _confetti.play();
+      if (_pool.isEmpty) {
+        _sessionTimer.stop();
+        _xp += _sessionXpBonus;
+        Future.delayed(const Duration(milliseconds: 500), _showSessionEnd);
+      }
+    } else {
+      HapticFeedback.heavyImpact();
+      setState(() {
+        _wrongAttempts += 1;
+        _streak = 0;
+        _missed[slotN] = (_missed[slotN] ?? 0) + 1;
+        _shakeSlot = slotN;
+      });
+      _shakeCtrl.forward(from: 0).whenComplete(() {
+        if (!mounted) return;
+        setState(() => _shakeSlot = null);
+      });
+    }
+  }
+
+  void _showSessionEnd() {
+    final attempts = _correct + _wrongAttempts;
+    final acc = attempts == 0 ? 0 : ((_correct * 100) / attempts).round();
+    _showAwesomeResult(
+      context: context,
+      title: 'সাজাও — সেশন শেষ',
+      scoreLabel: 'মোট XP: $_xp',
+      stats: [
+        'সঠিক স্থাপন: $_correct/${_heroNumbers.length}',
+        'ভুল চেষ্টা: $_wrongAttempts',
+        'নির্ভুলতা: $acc%',
+        'সেশন বোনাস: +$_sessionXpBonus XP',
+        'সেরা স্ট্রিক: $_bestStreak',
+        'সময়: ${_formatDuration(_sessionTimer.elapsed)}',
+      ],
+      missedLines: _missed.entries.toList()
+        ..sort((a, b) => b.value.compareTo(a.value)),
+      onPlayAgain: _newSession,
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final placedCount = _correct;
+    final progress = placedCount / _heroNumbers.length;
+
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(16, 0, 16, 16),
+      child: Stack(
+        clipBehavior: Clip.none,
+        children: [
+          // Confetti overlay
+          Align(
+            alignment: Alignment.topCenter,
+            child: IgnorePointer(
+              child: SizedBox(
+                height: 140,
+                width: double.infinity,
+                child: ConfettiWidget(
+                  confettiController: _confetti,
+                  blastDirectionality: BlastDirectionality.explosive,
+                  maxBlastForce: 16,
+                  minBlastForce: 6,
+                  emissionFrequency: 0.08,
+                  numberOfParticles: 12,
+                  gravity: 0.22,
+                  shouldLoop: false,
+                  colors: const [
+                    Color(0xFFFFE000),
+                    Color(0xFF10B981),
+                    _teal,
+                    Color(0xFF3B82F6),
+                  ],
+                ),
+              ),
+            ),
+          ),
+          Column(
+            children: [
+              // ── Header panel ───────────────────────────────────────
+              Container(
+                padding: const EdgeInsets.all(14),
+                decoration: BoxDecoration(
+                  color: const Color(0xFF1E293B),
+                  borderRadius: BorderRadius.circular(16),
+                  border: Border.all(color: _teal.withValues(alpha: 0.45)),
+                  boxShadow: [
+                    BoxShadow(
+                      color: _teal.withValues(alpha: 0.12),
+                      blurRadius: 18,
+                      offset: const Offset(0, 8),
+                    ),
+                  ],
+                ),
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.stretch,
+                  children: [
+                    Row(
+                      children: [
+                        const Icon(Icons.format_list_numbered_rounded,
+                            color: _teal, size: 22),
+                        const SizedBox(width: 8),
+                        const Expanded(
+                          child: Text(
+                            'সাজাও — ক্রম অনুযায়ী টেনে বসান',
+                            style: TextStyle(
+                                color: Colors.white,
+                                fontWeight: FontWeight.w900,
+                                fontSize: 13),
+                          ),
+                        ),
+                        Text(
+                          _formatDuration(_sessionTimer.elapsed),
+                          style: TextStyle(
+                            color: Colors.white.withValues(alpha: 0.85),
+                            fontWeight: FontWeight.w900,
+                          ),
+                        ),
+                      ],
+                    ),
+                    const SizedBox(height: 10),
+                    LinearProgressIndicator(
+                      minHeight: 8,
+                      borderRadius: BorderRadius.circular(99),
+                      value: progress.clamp(0, 1),
+                      backgroundColor: Colors.white.withValues(alpha: 0.12),
+                      valueColor: const AlwaysStoppedAnimation(_teal),
+                    ),
+                    const SizedBox(height: 8),
+                    Row(
+                      children: [
+                        Text(
+                          'স্থাপন: $placedCount/${_heroNumbers.length}',
+                          style: TextStyle(
+                              color: Colors.white.withValues(alpha: 0.82),
+                              fontWeight: FontWeight.w800),
+                        ),
+                        const Spacer(),
+                        Text('XP: $_xp',
+                            style: const TextStyle(
+                                color: Color(0xFFFFE000),
+                                fontWeight: FontWeight.w900)),
+                        const SizedBox(width: 10),
+                        Text('স্ট্রিক: $_streak',
+                            style: TextStyle(
+                                color: Colors.white.withValues(alpha: 0.82),
+                                fontWeight: FontWeight.w800)),
+                      ],
+                    ),
+                  ],
+                ),
+              ),
+              const SizedBox(height: 12),
+
+              // ── Slots grid (5 rows x 2 cols = 10) ─────────────────
+              Expanded(
+                child: GridView.builder(
+                  physics: const BouncingScrollPhysics(),
+                  itemCount: _heroNumbers.length,
+                  gridDelegate:
+                      const SliverGridDelegateWithFixedCrossAxisCount(
+                    crossAxisCount: 2,
+                    crossAxisSpacing: 10,
+                    mainAxisSpacing: 10,
+                    mainAxisExtent: 64,
+                  ),
+                  itemBuilder: (_, i) {
+                    final h = _heroNumbers[i];
+                    return _buildSlot(h);
+                  },
+                ),
+              ),
+
+              const SizedBox(height: 12),
+
+              // ── Chip pool ─────────────────────────────────────────
+              Container(
+                width: double.infinity,
+                constraints: const BoxConstraints(minHeight: 90),
+                padding: const EdgeInsets.all(12),
+                decoration: BoxDecoration(
+                  color: const Color(0xFF111827),
+                  borderRadius: BorderRadius.circular(16),
+                  border:
+                      Border.all(color: Colors.white.withValues(alpha: 0.08)),
+                ),
+                child: _pool.isEmpty
+                    ? const Center(
+                        child: Padding(
+                          padding: EdgeInsets.symmetric(vertical: 14),
+                          child: Text(
+                            'সব ঠিকঠাক সাজানো হয়েছে! 🎉',
+                            style: TextStyle(
+                              color: Color(0xFF10B981),
+                              fontWeight: FontWeight.w900,
+                              fontSize: 14,
+                            ),
+                          ),
+                        ),
+                      )
+                    : Wrap(
+                        spacing: 8,
+                        runSpacing: 8,
+                        alignment: WrapAlignment.center,
+                        children: [
+                          for (final chip in _pool) _buildChip(chip),
+                        ],
+                      ),
+              ),
+            ],
+          ),
+        ],
+      ),
+    );
+  }
+
+  // ─── Slot widget (drop target) ───────────────────────────────────────
+  Widget _buildSlot(_HeroNum h) {
+    final placed = _placed[h.n];
+    final isFilled = placed != null;
+    final isShaking = _shakeSlot == h.n;
+
+    return AnimatedBuilder(
+      animation: _shakeCtrl,
+      builder: (context, child) {
+        final t = isShaking ? _shakeCtrl.value : 0.0;
+        final dx = math.sin(t * math.pi * 6) * 8 * (1 - t);
+        return Transform.translate(offset: Offset(dx, 0), child: child);
+      },
+      child: DragTarget<_HeroNum>(
+        onWillAcceptWithDetails: (_) => !isFilled,
+        onAcceptWithDetails: (d) => _onDrop(h.n, d.data),
+        builder: (context, candidate, rejected) {
+          final hovering = candidate.isNotEmpty;
+          Color border;
+          Color bg;
+          if (isFilled) {
+            border = const Color(0xFF10B981);
+            bg = const Color(0xFF10B981).withValues(alpha: 0.18);
+          } else if (hovering) {
+            border = _teal;
+            bg = _teal.withValues(alpha: 0.18);
+          } else {
+            border = Colors.white.withValues(alpha: 0.18);
+            bg = Colors.white.withValues(alpha: 0.05);
+          }
+          return AnimatedContainer(
+            duration: const Duration(milliseconds: 160),
+            padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+            decoration: BoxDecoration(
+              color: bg,
+              borderRadius: BorderRadius.circular(14),
+              border: Border.all(
+                color: border,
+                width: hovering || isFilled ? 2.2 : 1.2,
+              ),
+            ),
+            child: Row(
+              children: [
+                Container(
+                  width: 38,
+                  height: 38,
+                  alignment: Alignment.center,
+                  decoration: BoxDecoration(
+                    gradient: isFilled
+                        ? const LinearGradient(
+                            colors: [Color(0xFF10B981), Color(0xFF059669)])
+                        : const LinearGradient(
+                            colors: [_teal, _tealDark]),
+                    borderRadius: BorderRadius.circular(10),
+                  ),
+                  child: Text(
+                    h.bnDigit,
+                    style: const TextStyle(
+                      color: Colors.white,
+                      fontSize: 18,
+                      fontWeight: FontWeight.w900,
+                    ),
+                  ),
+                ),
+                const SizedBox(width: 10),
+                Expanded(
+                  child: isFilled
+                      ? Row(
+                          children: [
+                            Expanded(
+                              child: Column(
+                                crossAxisAlignment: CrossAxisAlignment.start,
+                                mainAxisAlignment: MainAxisAlignment.center,
+                                mainAxisSize: MainAxisSize.min,
+                                children: [
+                                  Text(
+                                    placed.bnPronunciation,
+                                    style: const TextStyle(
+                                      color: Color(0xFF10B981),
+                                      fontSize: 16,
+                                      fontWeight: FontWeight.w900,
+                                      height: 1.0,
+                                    ),
+                                    maxLines: 1,
+                                    overflow: TextOverflow.ellipsis,
+                                  ),
+                                  const SizedBox(height: 2),
+                                  Text(
+                                    '${placed.kanji}  ${placed.kana}',
+                                    style: TextStyle(
+                                      color: Colors.white
+                                          .withValues(alpha: 0.65),
+                                      fontSize: 11,
+                                      fontWeight: FontWeight.w700,
+                                      height: 1.0,
+                                    ),
+                                    maxLines: 1,
+                                    overflow: TextOverflow.ellipsis,
+                                  ),
+                                ],
+                              ),
+                            ),
+                            const Icon(Icons.check_circle_rounded,
+                                color: Color(0xFF10B981), size: 20),
+                          ],
+                        )
+                      : Text(
+                          hovering ? 'এখানে বসান' : 'এখানে টেনে আনুন',
+                          style: TextStyle(
+                            color: hovering
+                                ? _teal
+                                : Colors.white.withValues(alpha: 0.5),
+                            fontSize: 12,
+                            fontWeight: FontWeight.w700,
+                          ),
+                          maxLines: 1,
+                          overflow: TextOverflow.ellipsis,
+                        ),
+                ),
+              ],
+            ),
+          );
+        },
+      ),
+    );
+  }
+
+  // ─── Draggable chip ────────────────────────────────────────────────
+  Widget _buildChip(_HeroNum h) {
+    final chipWidget = Container(
+      padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 10),
+      decoration: BoxDecoration(
+        gradient: const LinearGradient(
+          colors: [_teal, _tealDark],
+          begin: Alignment.topLeft,
+          end: Alignment.bottomRight,
+        ),
+        borderRadius: BorderRadius.circular(99),
+        boxShadow: [
+          BoxShadow(
+            color: _teal.withValues(alpha: 0.35),
+            blurRadius: 10,
+            offset: const Offset(0, 4),
+          ),
+        ],
+      ),
+      child: Text(
+        h.bnPronunciation,
+        style: const TextStyle(
+          color: Colors.white,
+          fontSize: 16,
+          fontWeight: FontWeight.w900,
+        ),
+      ),
+    );
+
+    return Draggable<_HeroNum>(
+      data: h,
+      onDragStarted: HapticFeedback.selectionClick,
+      feedback: Material(
+        color: Colors.transparent,
+        child: Transform.scale(
+          scale: 1.15,
+          child: Opacity(opacity: 0.95, child: chipWidget),
+        ),
+      ),
+      childWhenDragging: Opacity(
+        opacity: 0.35,
+        child: chipWidget,
+      ),
+      child: chipWidget,
+    );
+  }
+}
+
+// ═════════════════════════════════════════════════════════════════════
+// ১-১০ বলো — Speak the entire sequence 1..10 in Japanese in one go
+// STT listens, then per-position evaluation (correct/wrong/missed)
+// ═════════════════════════════════════════════════════════════════════
+
+enum _SeqStatus { pending, correct, wrong, missed, extra }
+
+class _SeqEvalEntry {
+  const _SeqEvalEntry({required this.expected, required this.heard, required this.status});
+  final _HeroNum expected;
+  final int? heard; // heard number (1..10) or null if missed
+  final _SeqStatus status;
+}
+
+class _HeroSpeakSequenceGame extends StatefulWidget {
+  const _HeroSpeakSequenceGame({super.key});
+
+  @override
+  State<_HeroSpeakSequenceGame> createState() => _HeroSpeakSequenceGameState();
+}
+
+class _HeroSpeakSequenceGameState extends State<_HeroSpeakSequenceGame>
+    with TickerProviderStateMixin {
+  static const _rose = Color(0xFFE11D48);
+  static const _roseDark = Color(0xFFBE123C);
+
+  final _stt = SpeechToText();
+  final _tts = FlutterTts();
+  bool _sttReady = false;
+  bool _ttsReady = false;
+  String? _locale;
+  String? _error;
+
+  bool _listening = false;
+  String _heard = '';
+  double _soundLevel = 0;
+  int _secondsLeft = 0;
+  Timer? _recordTimer;
+  static const _maxSeconds = 25;
+
+  late List<_SeqEvalEntry> _results;
+  List<int> _extras = const [];
+  bool _evaluated = false;
+
+  int _xp = 0;
+  int _attempts = 0;
+  int _bestCorrect = 0;
+  final Stopwatch _sessionTimer = Stopwatch();
+
+  late ConfettiController _confetti;
+  late AnimationController _pulseCtrl;
+  late AnimationController _waveCtrl;
+
+  @override
+  void initState() {
+    super.initState();
+    _results = _heroNumbers
+        .map((h) =>
+            _SeqEvalEntry(expected: h, heard: null, status: _SeqStatus.pending))
+        .toList();
+    _confetti = ConfettiController(duration: const Duration(milliseconds: 900));
+    _pulseCtrl = AnimationController(
+        vsync: this, duration: const Duration(milliseconds: 1100))
+      ..repeat(reverse: true);
+    _waveCtrl = AnimationController(
+        vsync: this, duration: const Duration(milliseconds: 900))
+      ..repeat();
+    _sessionTimer.start();
+    _initTts();
+    _initStt();
+  }
+
+  @override
+  void dispose() {
+    _recordTimer?.cancel();
+    _confetti.dispose();
+    _pulseCtrl.dispose();
+    _waveCtrl.dispose();
+    _stt.stop();
+    _tts.stop();
+    super.dispose();
+  }
+
+  Future<void> _initTts() async {
+    try {
+      await _tts.setLanguage('ja-JP');
+      await _tts.setSpeechRate(0.45);
+      await _tts.setPitch(1.05);
+      if (mounted) setState(() => _ttsReady = true);
+    } catch (_) {}
+  }
+
+  Future<void> _initStt() async {
+    try {
+      final ok = await _stt.initialize(
+        onError: (e) {
+          if (!mounted) return;
+          setState(() => _error = e.errorMsg);
+        },
+        onStatus: (_) {},
+      );
+      if (!mounted) return;
+      if (!ok) {
+        setState(() => _sttReady = false);
+        return;
+      }
+      final locales = await _stt.locales();
+      final ja =
+          locales.where((l) => l.localeId.toLowerCase().startsWith('ja'));
+      setState(() {
+        _locale = ja.isNotEmpty
+            ? ja.first.localeId
+            : (locales.isNotEmpty ? locales.first.localeId : null);
+        _sttReady = true;
+      });
+    } catch (e) {
+      if (!mounted) return;
+      setState(() {
+        _sttReady = false;
+        _error = '$e';
+      });
+    }
+  }
+
+  // ─── Token → number matcher ───────────────────────────────────────
+  static int? _matchToken(String s) {
+    switch (s) {
+      case 'ichi':
+      case 'いち':
+      case 'イチ':
+      case '一':
+      case '1':
+      case '১':
+        return 1;
+      case 'ni':
+      case 'に':
+      case 'ニ':
+      case '二':
+      case '2':
+      case '২':
+        return 2;
+      case 'san':
+      case 'sun':
+      case 'さん':
+      case 'サン':
+      case '三':
+      case '3':
+      case '৩':
+        return 3;
+      case 'yon':
+      case 'shi':
+      case 'yo':
+      case 'よん':
+      case 'ヨン':
+      case 'し':
+      case 'シ':
+      case '四':
+      case '4':
+      case '৪':
+        return 4;
+      case 'go':
+      case 'ご':
+      case 'ゴ':
+      case '五':
+      case '5':
+      case '৫':
+        return 5;
+      case 'roku':
+      case 'ろく':
+      case 'ロク':
+      case '六':
+      case '6':
+      case '৬':
+        return 6;
+      case 'nana':
+      case 'shichi':
+      case 'なな':
+      case 'ナナ':
+      case 'しち':
+      case 'シチ':
+      case '七':
+      case '7':
+      case '৭':
+        return 7;
+      case 'hachi':
+      case 'はち':
+      case 'ハチ':
+      case '八':
+      case '8':
+      case '৮':
+        return 8;
+      case 'kyu':
+      case 'kyuu':
+      case 'kyou':
+      case 'ku':
+      case 'きゅう':
+      case 'キュウ':
+      case 'きゅ':
+      case 'く':
+      case 'ク':
+      case '九':
+      case '9':
+      case '৯':
+        return 9;
+      case 'ju':
+      case 'juu':
+      case 'jyu':
+      case 'jyuu':
+      case 'jou':
+      case 'zyu':
+      case 'zyuu':
+      case 'じゅう':
+      case 'ジュウ':
+      case 'じゅ':
+      case 'ジュ':
+      case 'じょう':
+      case 'ジョウ':
+      case 'じょ':
+      case 'ジョ':
+      case '十':
+      case '拾':
+      case '10':
+      case '১০':
+        return 10;
+    }
+    return null;
+  }
+
+  // Normalize STT output for robust matching.
+  // - Lowercase ASCII
+  // - Fullwidth digits (０-９) → halfwidth (0-9)
+  // - Strip Japanese long-vowel mark "ー"
+  // - Small kana (ぁぃぅぇぉ etc.) → large equivalents
+  static String _normalize(String s) {
+    var out = s.toLowerCase();
+    final buf = StringBuffer();
+    for (final r in out.runes) {
+      // Fullwidth digit → halfwidth
+      if (r >= 0xFF10 && r <= 0xFF19) {
+        buf.writeCharCode(r - 0xFF10 + 0x30);
+        continue;
+      }
+      // Skip long vowel mark
+      if (r == 0x30FC) continue;
+      // Small hiragana → big
+      const smallToBig = {
+        0x3041: 0x3042, // ぁ→あ
+        0x3043: 0x3044, // ぃ→い
+        0x3045: 0x3046, // ぅ→う
+        0x3047: 0x3048, // ぇ→え
+        0x3049: 0x304A, // ぉ→お
+        // Small katakana → big
+        0x30A1: 0x30A2, // ァ→ア
+        0x30A3: 0x30A4, // ィ→イ
+        0x30A5: 0x30A6, // ゥ→ウ
+        0x30A7: 0x30A8, // ェ→エ
+        0x30A9: 0x30AA, // ォ→オ
+      };
+      buf.writeCharCode(smallToBig[r] ?? r);
+    }
+    return buf.toString();
+  }
+
+  List<int> _parseHeard(String raw) {
+    final cleaned = _normalize(raw)
+        .replaceAll(RegExp(r'[、。,.!?・〜\-‐–—()\[\]「」]'), ' ');
+    final tokens =
+        cleaned.split(RegExp(r'\s+')).where((s) => s.isNotEmpty);
+    final out = <int>[];
+    for (final t in tokens) {
+      final exact = _matchToken(t);
+      if (exact != null) {
+        out.add(exact);
+        continue;
+      }
+      // Greedy substring match for concatenated kana/kanji (e.g. "いちにさん").
+      int i = 0;
+      while (i < t.length) {
+        bool matched = false;
+        final maxLen = math.min(6, t.length - i);
+        for (int len = maxLen; len >= 1 && !matched; len--) {
+          final sub = t.substring(i, i + len);
+          final n = _matchToken(sub);
+          if (n != null) {
+            out.add(n);
+            i += len;
+            matched = true;
+          }
+        }
+        if (!matched) i++;
+      }
+    }
+    return out;
+  }
+
+  void _evaluate(List<int> heard) {
+    final entries = <_SeqEvalEntry>[];
+    int correctCount = 0;
+    for (var i = 0; i < _heroNumbers.length; i++) {
+      final expected = _heroNumbers[i];
+      if (i >= heard.length) {
+        entries.add(_SeqEvalEntry(
+            expected: expected, heard: null, status: _SeqStatus.missed));
+        continue;
+      }
+      final h = heard[i];
+      if (h == expected.n) {
+        entries.add(_SeqEvalEntry(
+            expected: expected, heard: h, status: _SeqStatus.correct));
+        correctCount++;
+      } else {
+        entries.add(_SeqEvalEntry(
+            expected: expected, heard: h, status: _SeqStatus.wrong));
+      }
+    }
+    final extras = heard.length > _heroNumbers.length
+        ? heard.sublist(_heroNumbers.length)
+        : const <int>[];
+
+    _attempts += 1;
+    if (correctCount > _bestCorrect) _bestCorrect = correctCount;
+    // XP: +10 per correct slot, +50 bonus for perfect run.
+    final delta = correctCount * 10 + (correctCount == 10 ? 50 : 0);
+    _xp += delta;
+
+    setState(() {
+      _results = entries;
+      _extras = extras;
+      _evaluated = true;
+    });
+
+    if (correctCount == 10 && extras.isEmpty) {
+      HapticFeedback.heavyImpact();
+      _confetti.play();
+    } else if (correctCount >= 7) {
+      HapticFeedback.mediumImpact();
+    } else {
+      HapticFeedback.lightImpact();
+    }
+  }
+
+  Future<void> _startListening() async {
+    if (_listening) return;
+    HapticFeedback.mediumImpact();
+    setState(() {
+      _heard = '';
+      _error = null;
+      _evaluated = false;
+      _extras = const [];
+      _results = _heroNumbers
+          .map((h) => _SeqEvalEntry(
+              expected: h, heard: null, status: _SeqStatus.pending))
+          .toList();
+      _secondsLeft = _maxSeconds;
+      _soundLevel = 0;
+    });
+    try {
+      if (!_sttReady) {
+        await _initStt();
+      }
+      if (!_sttReady) {
+        throw Exception('Speech recognition এই ডিভাইসে কাজ করছে না।');
+      }
+      await _stt.listen(
+        localeId: _locale,
+        listenMode: ListenMode.dictation,
+        partialResults: true,
+        cancelOnError: true,
+        listenFor: const Duration(seconds: _maxSeconds),
+        pauseFor: const Duration(seconds: 4),
+        onResult: (SpeechRecognitionResult r) {
+          if (!mounted) return;
+          setState(() => _heard = r.recognizedWords);
+        },
+        onSoundLevelChange: (level) {
+          if (!mounted) return;
+          setState(() => _soundLevel = level);
+        },
+      );
+      if (!mounted) return;
+      setState(() => _listening = true);
+      _recordTimer?.cancel();
+      _recordTimer = Timer.periodic(const Duration(seconds: 1), (_) async {
+        if (!mounted || !_listening) return;
+        if (_secondsLeft <= 1) {
+          await _stopAndEvaluate();
+          return;
+        }
+        setState(() => _secondsLeft -= 1);
+      });
+    } catch (e) {
+      if (!mounted) return;
+      _recordTimer?.cancel();
+      setState(() {
+        _listening = false;
+        _error = '$e';
+      });
+    }
+  }
+
+  Future<void> _stopAndEvaluate() async {
+    if (!_listening) return;
+    _recordTimer?.cancel();
+    HapticFeedback.selectionClick();
+    await _stt.stop();
+    if (!mounted) return;
+    setState(() {
+      _listening = false;
+      _secondsLeft = 0;
+      _soundLevel = 0;
+    });
+    final parsed = _parseHeard(_heard);
+    _evaluate(parsed);
+  }
+
+  Future<void> _speakSequence() async {
+    if (!_ttsReady) return;
+    HapticFeedback.selectionClick();
+    await _tts.stop();
+    for (final h in _heroNumbers) {
+      if (!mounted) return;
+      await _tts.speak(h.kana);
+      await Future.delayed(const Duration(milliseconds: 320));
+    }
+  }
+
+  Future<void> _speakMistakes() async {
+    if (!_ttsReady) return;
+    HapticFeedback.selectionClick();
+    await _tts.stop();
+    final mistakes = _results.where(
+        (r) => r.status == _SeqStatus.wrong || r.status == _SeqStatus.missed);
+    for (final r in mistakes) {
+      if (!mounted) return;
+      await _tts.speak(r.expected.kana);
+      await Future.delayed(const Duration(milliseconds: 380));
+    }
+  }
+
+  // ─── UI ─────────────────────────────────────────────────────────────
+  @override
+  Widget build(BuildContext context) {
+    final correctCount =
+        _results.where((r) => r.status == _SeqStatus.correct).length;
+    final wrongCount =
+        _results.where((r) => r.status == _SeqStatus.wrong).length;
+    final missedCount =
+        _results.where((r) => r.status == _SeqStatus.missed).length;
+    final accuracy =
+        _evaluated ? ((correctCount * 100) / _heroNumbers.length).round() : 0;
+
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(16, 0, 16, 16),
+      child: Stack(
+        clipBehavior: Clip.none,
+        children: [
+          Align(
+            alignment: Alignment.topCenter,
+            child: IgnorePointer(
+              child: SizedBox(
+                height: 140,
+                width: double.infinity,
+                child: ConfettiWidget(
+                  confettiController: _confetti,
+                  blastDirectionality: BlastDirectionality.explosive,
+                  maxBlastForce: 18,
+                  minBlastForce: 6,
+                  emissionFrequency: 0.08,
+                  numberOfParticles: 18,
+                  gravity: 0.22,
+                  shouldLoop: false,
+                  colors: const [
+                    Color(0xFFFFE000),
+                    Color(0xFF10B981),
+                    _rose,
+                    Color(0xFF3B82F6),
+                  ],
+                ),
+              ),
+            ),
+          ),
+          Column(
+            children: [
+              _buildHeader(correctCount, accuracy),
+              const SizedBox(height: 12),
+              _buildMicCard(),
+              const SizedBox(height: 12),
+              if (_evaluated)
+                _buildResultsSummary(correctCount, wrongCount, missedCount),
+              if (_evaluated) const SizedBox(height: 10),
+              Expanded(child: _buildPositionGrid()),
+              if (_evaluated) ...[
+                const SizedBox(height: 10),
+                _buildActionRow(),
+              ],
+            ],
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildHeader(int correctCount, int accuracy) {
+    return Container(
+      padding: const EdgeInsets.all(14),
+      decoration: BoxDecoration(
+        color: const Color(0xFF1E293B),
+        borderRadius: BorderRadius.circular(16),
+        border: Border.all(color: _rose.withValues(alpha: 0.45)),
+        boxShadow: [
+          BoxShadow(
+            color: _rose.withValues(alpha: 0.12),
+            blurRadius: 18,
+            offset: const Offset(0, 8),
+          ),
+        ],
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          Row(
+            children: [
+              const Icon(Icons.record_voice_over_rounded,
+                  color: _rose, size: 22),
+              const SizedBox(width: 8),
+              const Expanded(
+                child: Text(
+                  '১-১০ বলো — এক টানে জাপানিতে বলুন',
+                  style: TextStyle(
+                      color: Colors.white,
+                      fontWeight: FontWeight.w900,
+                      fontSize: 13),
+                ),
+              ),
+              if (_listening)
+                Text(
+                  '$_secondsLeft s',
+                  style: const TextStyle(
+                    color: _rose,
+                    fontWeight: FontWeight.w900,
+                  ),
+                ),
+            ],
+          ),
+          const SizedBox(height: 10),
+          LinearProgressIndicator(
+            minHeight: 8,
+            borderRadius: BorderRadius.circular(99),
+            value: _evaluated ? correctCount / _heroNumbers.length : 0,
+            backgroundColor: Colors.white.withValues(alpha: 0.12),
+            valueColor: const AlwaysStoppedAnimation(_rose),
+          ),
+          const SizedBox(height: 8),
+          Row(
+            children: [
+              Text(
+                _evaluated
+                    ? 'সঠিক: $correctCount/${_heroNumbers.length}'
+                    : 'মাইক চাপুন',
+                style: TextStyle(
+                    color: Colors.white.withValues(alpha: 0.82),
+                    fontWeight: FontWeight.w800),
+              ),
+              const Spacer(),
+              Text('XP: $_xp',
+                  style: const TextStyle(
+                      color: Color(0xFFFFE000),
+                      fontWeight: FontWeight.w900)),
+              const SizedBox(width: 10),
+              Text(
+                'সেরা: $_bestCorrect/10',
+                style: TextStyle(
+                    color: Colors.white.withValues(alpha: 0.82),
+                    fontWeight: FontWeight.w800),
+              ),
+            ],
+          ),
+          if (_evaluated)
+            Padding(
+              padding: const EdgeInsets.only(top: 6),
+              child: Text(
+                'নির্ভুলতা: $accuracy%',
+                style: TextStyle(
+                  color: Colors.white.withValues(alpha: 0.75),
+                  fontWeight: FontWeight.w700,
+                  fontSize: 12,
+                ),
+              ),
+            ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildMicCard() {
+    return Container(
+      width: double.infinity,
+      padding: const EdgeInsets.fromLTRB(16, 14, 16, 16),
+      decoration: BoxDecoration(
+        gradient: const LinearGradient(
+          colors: [Color(0xFF1E293B), Color(0xFF111827)],
+          begin: Alignment.topLeft,
+          end: Alignment.bottomRight,
+        ),
+        borderRadius: BorderRadius.circular(20),
+        border: Border.all(color: _rose.withValues(alpha: 0.55), width: 2),
+        boxShadow: [
+          BoxShadow(
+            color: _rose.withValues(alpha: 0.20),
+            blurRadius: 22,
+            offset: const Offset(0, 8),
+          ),
+        ],
+      ),
+      child: Column(
+        children: [
+          if (!_listening && !_evaluated)
+            Text(
+              'ইচি, নি, সান, ইয়োন … জু — সব এক সাথে বলুন',
+              textAlign: TextAlign.center,
+              style: TextStyle(
+                color: Colors.white.withValues(alpha: 0.78),
+                fontSize: 12,
+                fontWeight: FontWeight.w700,
+              ),
+            ),
+          const SizedBox(height: 10),
+          GestureDetector(
+            onTap: _listening ? _stopAndEvaluate : _startListening,
+            child: AnimatedBuilder(
+              animation: _pulseCtrl,
+              builder: (context, _) {
+                final scale = _listening
+                    ? 1 + (_pulseCtrl.value * 0.08) + (_soundLevel.clamp(0, 10) / 60)
+                    : 1.0;
+                return Transform.scale(
+                  scale: scale,
+                  child: Container(
+                    width: 78,
+                    height: 78,
+                    decoration: BoxDecoration(
+                      shape: BoxShape.circle,
+                      gradient: LinearGradient(
+                        colors: _listening
+                            ? const [Color(0xFFEF4444), Color(0xFFB91C1C)]
+                            : const [_rose, _roseDark],
+                        begin: Alignment.topLeft,
+                        end: Alignment.bottomRight,
+                      ),
+                      boxShadow: [
+                        BoxShadow(
+                          color: (_listening ? const Color(0xFFEF4444) : _rose)
+                              .withValues(alpha: 0.5),
+                          blurRadius: 22,
+                          spreadRadius: 2,
+                        ),
+                      ],
+                    ),
+                    child: Icon(
+                      _listening
+                          ? Icons.stop_rounded
+                          : Icons.mic_rounded,
+                      color: Colors.white,
+                      size: 38,
+                    ),
+                  ),
+                );
+              },
+            ),
+          ),
+          const SizedBox(height: 10),
+          Text(
+            _listening ? 'শুনছি — বলতে থাকুন…' : (_evaluated ? 'আবার চেষ্টা করতে মাইক চাপুন' : 'মাইক চাপুন'),
+            style: const TextStyle(
+              color: Colors.white,
+              fontWeight: FontWeight.w900,
+              fontSize: 13,
+            ),
+          ),
+          if (_heard.isNotEmpty) ...[
+            const SizedBox(height: 10),
+            Container(
+              width: double.infinity,
+              padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+              decoration: BoxDecoration(
+                color: Colors.white.withValues(alpha: 0.06),
+                borderRadius: BorderRadius.circular(10),
+                border:
+                    Border.all(color: Colors.white.withValues(alpha: 0.12)),
+              ),
+              child: Text(
+                _heard,
+                textAlign: TextAlign.center,
+                style: const TextStyle(
+                  color: Color(0xFFFFE000),
+                  fontWeight: FontWeight.w900,
+                  fontSize: 14,
+                  height: 1.3,
+                ),
+              ),
+            ),
+          ],
+          if (_error != null) ...[
+            const SizedBox(height: 8),
+            Text(
+              _error!,
+              style: const TextStyle(
+                color: Color(0xFFEF4444),
+                fontSize: 11,
+                fontWeight: FontWeight.w700,
+              ),
+              textAlign: TextAlign.center,
+            ),
+          ],
+        ],
+      ),
+    );
+  }
+
+  Widget _buildResultsSummary(int correct, int wrong, int missed) {
+    return Row(
+      children: [
+        _summaryChip(
+            label: 'সঠিক', value: '$correct', color: const Color(0xFF10B981)),
+        const SizedBox(width: 8),
+        _summaryChip(
+            label: 'ভুল', value: '$wrong', color: const Color(0xFFEF4444)),
+        const SizedBox(width: 8),
+        _summaryChip(
+            label: 'বাদ', value: '$missed', color: const Color(0xFFF59E0B)),
+        if (_extras.isNotEmpty) ...[
+          const SizedBox(width: 8),
+          _summaryChip(
+              label: 'অতিরিক্ত',
+              value: '${_extras.length}',
+              color: const Color(0xFF8B5CF6)),
+        ],
+      ],
+    );
+  }
+
+  Widget _summaryChip(
+      {required String label, required String value, required Color color}) {
+    return Expanded(
+      child: Container(
+        padding: const EdgeInsets.symmetric(vertical: 8),
+        decoration: BoxDecoration(
+          color: color.withValues(alpha: 0.15),
+          borderRadius: BorderRadius.circular(12),
+          border: Border.all(color: color.withValues(alpha: 0.5)),
+        ),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Text(value,
+                style: TextStyle(
+                    color: color,
+                    fontSize: 18,
+                    fontWeight: FontWeight.w900)),
+            Text(label,
+                style: TextStyle(
+                    color: color,
+                    fontSize: 10,
+                    fontWeight: FontWeight.w700)),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildPositionGrid() {
+    return GridView.builder(
+      physics: const BouncingScrollPhysics(),
+      itemCount: _results.length,
+      gridDelegate: const SliverGridDelegateWithFixedCrossAxisCount(
+        crossAxisCount: 2,
+        crossAxisSpacing: 10,
+        mainAxisSpacing: 10,
+        mainAxisExtent: 78,
+      ),
+      itemBuilder: (_, i) => _buildPositionTile(_results[i]),
+    );
+  }
+
+  Widget _buildPositionTile(_SeqEvalEntry r) {
+    Color color;
+    IconData icon;
+    String detail;
+    switch (r.status) {
+      case _SeqStatus.correct:
+        color = const Color(0xFF10B981);
+        icon = Icons.check_circle_rounded;
+        detail = 'বলেছেন ✓';
+        break;
+      case _SeqStatus.wrong:
+        final heardItem =
+            _heroNumbers.firstWhere((h) => h.n == r.heard, orElse: () => r.expected);
+        color = const Color(0xFFEF4444);
+        icon = Icons.cancel_rounded;
+        detail = 'বলেছেন: ${heardItem.bnPronunciation}';
+        break;
+      case _SeqStatus.missed:
+        color = const Color(0xFFF59E0B);
+        icon = Icons.remove_circle_outline_rounded;
+        detail = 'বাদ পড়েছে';
+        break;
+      case _SeqStatus.pending:
+        color = Colors.white.withValues(alpha: 0.3);
+        icon = Icons.radio_button_unchecked_rounded;
+        detail = 'অপেক্ষমাণ';
+        break;
+      case _SeqStatus.extra:
+        color = const Color(0xFF8B5CF6);
+        icon = Icons.add_circle_outline_rounded;
+        detail = 'অতিরিক্ত';
+        break;
+    }
+
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 8),
+      decoration: BoxDecoration(
+        color: color.withValues(alpha: 0.10),
+        borderRadius: BorderRadius.circular(14),
+        border: Border.all(color: color.withValues(alpha: 0.55)),
+      ),
+      child: Row(
+        children: [
+          Container(
+            width: 34,
+            height: 34,
+            alignment: Alignment.center,
+            decoration: BoxDecoration(
+              color: color.withValues(alpha: 0.20),
+              borderRadius: BorderRadius.circular(10),
+            ),
+            child: Text(
+              r.expected.bnDigit,
+              style: TextStyle(
+                color: color,
+                fontSize: 15,
+                fontWeight: FontWeight.w900,
+              ),
+            ),
+          ),
+          const SizedBox(width: 8),
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              mainAxisAlignment: MainAxisAlignment.center,
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                Text(
+                  r.expected.bnPronunciation,
+                  style: const TextStyle(
+                    color: Colors.white,
+                    fontSize: 14,
+                    fontWeight: FontWeight.w900,
+                    height: 1.0,
+                  ),
+                  maxLines: 1,
+                  overflow: TextOverflow.ellipsis,
+                ),
+                const SizedBox(height: 2),
+                Text(
+                  detail,
+                  style: TextStyle(
+                    color: color,
+                    fontSize: 11,
+                    fontWeight: FontWeight.w700,
+                    height: 1.1,
+                  ),
+                  maxLines: 1,
+                  overflow: TextOverflow.ellipsis,
+                ),
+              ],
+            ),
+          ),
+          Icon(icon, color: color, size: 22),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildActionRow() {
+    return Row(
+      children: [
+        Expanded(
+          child: OutlinedButton.icon(
+            onPressed: _ttsReady ? _speakSequence : null,
+            style: OutlinedButton.styleFrom(
+              foregroundColor: Colors.white,
+              side: BorderSide(color: Colors.white.withValues(alpha: 0.4)),
+              padding: const EdgeInsets.symmetric(vertical: 12),
+              shape: RoundedRectangleBorder(
+                  borderRadius: BorderRadius.circular(12)),
+            ),
+            icon: const Icon(Icons.volume_up_rounded),
+            label: const Text('সব শুনুন',
+                style: TextStyle(fontWeight: FontWeight.w900)),
+          ),
+        ),
+        const SizedBox(width: 10),
+        Expanded(
+          child: ElevatedButton.icon(
+            onPressed: _ttsReady ? _speakMistakes : null,
+            style: ElevatedButton.styleFrom(
+              backgroundColor: _rose,
+              foregroundColor: Colors.white,
+              padding: const EdgeInsets.symmetric(vertical: 12),
+              shape: RoundedRectangleBorder(
+                  borderRadius: BorderRadius.circular(12)),
+            ),
+            icon: const Icon(Icons.school_rounded),
+            label: const Text('ভুলগুলি শুনুন',
+                style: TextStyle(fontWeight: FontWeight.w900)),
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+class _TopBar extends StatelessWidget {
+  const _TopBar({required this.score, required this.lives});
+  final int score;
+  final int lives;
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.all(14),
+      decoration: _cardDeco(),
+      child: Row(
+        children: [
+          const Icon(Icons.score_rounded, color: Color(0xFFFFE000), size: 18),
+          const SizedBox(width: 6),
+          Text('স্কোর: $score',
+              style: const TextStyle(color: Colors.white, fontWeight: FontWeight.w900)),
+          const Spacer(),
+          for (var i = 0; i < 3; i++)
+            Padding(
+              padding: const EdgeInsets.only(left: 4),
+              child: Icon(Icons.favorite_rounded,
+                  size: 18, color: i < lives ? const Color(0xFFEF4444) : const Color(0xFF94A3B8)),
+            )
+        ],
+      ),
+    );
+  }
+}
+
+void _showAwesomeResult({
+  required BuildContext context,
+  required String title,
+  required String scoreLabel,
+  required List<String> stats,
+  required List<MapEntry<int, int>> missedLines,
+  required VoidCallback onPlayAgain,
+}) {
+  final missed = <String>[];
+  for (final e in missedLines.take(6)) {
+    final it = _heroNumbers.firstWhere((x) => x.n == e.key);
+    missed.add('${it.kanji} ${it.kana} (${it.bnPronunciation}) → ${it.bnDigit} ${it.bnWord}  ×${e.value}');
+  }
+  showModalBottomSheet<void>(
+    context: context,
+    backgroundColor: Colors.transparent,
+    isScrollControlled: true,
+    builder: (_) => _AwesomeResultSheet(
+      title: title,
+      scoreLabel: scoreLabel,
+      stats: stats,
+      missed: missed,
+      onPlayAgain: onPlayAgain,
+    ),
+  );
+}
+
+class _AwesomeResultSheet extends StatelessWidget {
+  const _AwesomeResultSheet({
+    required this.title,
+    required this.scoreLabel,
+    required this.stats,
+    required this.missed,
+    required this.onPlayAgain,
+  });
+
+  final String title;
+  final String scoreLabel;
+  final List<String> stats;
+  final List<String> missed;
+  final VoidCallback onPlayAgain;
+
+  @override
+  Widget build(BuildContext context) {
+    return SafeArea(
+      child: Container(
+        margin: const EdgeInsets.fromLTRB(16, 0, 16, 16),
+        padding: const EdgeInsets.all(16),
+        decoration: BoxDecoration(
+          color: const Color(0xFF0B1326),
+          borderRadius: BorderRadius.circular(22),
+          border: Border.all(color: const Color(0xFFFFE000).withValues(alpha: 0.18)),
+          boxShadow: [
+            BoxShadow(
+              color: Colors.black.withValues(alpha: 0.35),
+              blurRadius: 22,
+              offset: const Offset(0, 12),
+            )
+          ],
+        ),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            Row(
+              children: [
+                const Icon(Icons.emoji_events_rounded, color: Color(0xFFFFE000)),
+                const SizedBox(width: 10),
+                Expanded(
+                  child: Text(title,
+                      style: const TextStyle(color: Colors.white, fontWeight: FontWeight.w900, fontSize: 16)),
+                ),
+                IconButton(
+                  onPressed: () => Navigator.pop(context),
+                  icon: const Icon(Icons.close_rounded, color: Colors.white),
+                ),
+              ],
+            ),
+            const SizedBox(height: 6),
+            Container(
+              padding: const EdgeInsets.all(14),
+              decoration: BoxDecoration(
+                color: Colors.white.withValues(alpha: 0.06),
+                borderRadius: BorderRadius.circular(16),
+                border: Border.all(color: Colors.white.withValues(alpha: 0.10)),
+              ),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(scoreLabel,
+                      style: const TextStyle(color: Color(0xFFFFE000), fontWeight: FontWeight.w900, fontSize: 22)),
+                  const SizedBox(height: 10),
+                  Wrap(
+                    spacing: 8,
+                    runSpacing: 8,
+                    children: [
+                      for (final s in stats)
+                        Container(
+                          padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 6),
+                          decoration: BoxDecoration(
+                            color: const Color(0xFF1E293B),
+                            borderRadius: BorderRadius.circular(999),
+                            border: Border.all(color: Colors.white.withValues(alpha: 0.10)),
+                          ),
+                          child: Text(s,
+                              style: TextStyle(
+                                  color: Colors.white.withValues(alpha: 0.92),
+                                  fontWeight: FontWeight.w800,
+                                  fontSize: 12)),
+                        ),
+                    ],
+                  ),
+                ],
+              ),
+            ),
+            if (missed.isNotEmpty) ...[
+              const SizedBox(height: 12),
+              const Text('যেগুলো মিস হয়েছে',
+                  style: TextStyle(color: Colors.white, fontWeight: FontWeight.w900)),
+              const SizedBox(height: 8),
+              for (final m in missed)
+                Padding(
+                  padding: const EdgeInsets.only(bottom: 8),
+                  child: Container(
+                    padding: const EdgeInsets.all(12),
+                    decoration: BoxDecoration(
+                      color: Colors.white.withValues(alpha: 0.05),
+                      borderRadius: BorderRadius.circular(14),
+                      border: Border.all(color: Colors.white.withValues(alpha: 0.10)),
+                    ),
+                    child: Text(m,
+                        style: TextStyle(color: Colors.white.withValues(alpha: 0.92), fontWeight: FontWeight.w800)),
+                  ),
+                ),
+            ],
+            const SizedBox(height: 10),
+            ElevatedButton.icon(
+              onPressed: () {
+                Navigator.pop(context);
+                onPlayAgain();
+              },
+              style: ElevatedButton.styleFrom(
+                backgroundColor: const Color(0xFFFFE000),
+                foregroundColor: const Color(0xFF1E293B),
+                padding: const EdgeInsets.symmetric(vertical: 12),
+                shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(14)),
+              ),
+              icon: const Icon(Icons.refresh_rounded),
+              label: const Text('আবার খেলি', style: TextStyle(fontWeight: FontWeight.w900)),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+BoxDecoration _cardDeco() => BoxDecoration(
+      color: const Color(0xFF1E293B),
+      borderRadius: BorderRadius.circular(16),
+      border: Border.all(color: Colors.white.withValues(alpha: 0.10)),
+    );

--- a/lib/screens/n5_hi_hello_lesson_screen.dart
+++ b/lib/screens/n5_hi_hello_lesson_screen.dart
@@ -1,0 +1,3819 @@
+// ignore_for_file: deprecated_member_use
+
+import 'dart:async';
+import 'dart:math' as math;
+
+import 'package:confetti/confetti.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_tts/flutter_tts.dart';
+import 'package:get/get.dart';
+import 'package:speech_to_text/speech_recognition_result.dart';
+import 'package:speech_to_text/speech_to_text.dart';
+
+class N5HiHelloLessonScreen extends StatefulWidget {
+  const N5HiHelloLessonScreen({super.key});
+
+  @override
+  State<N5HiHelloLessonScreen> createState() => _N5HiHelloLessonScreenState();
+}
+
+enum _HiTab { flashcard, quiz, match, rush, listen, read, speak }
+
+class _N5HiHelloLessonScreenState extends State<N5HiHelloLessonScreen> {
+  static const _tabs = [
+    _HiTab.listen,
+    _HiTab.read,
+    _HiTab.speak,
+    _HiTab.flashcard,
+    _HiTab.quiz,
+    _HiTab.match,
+    _HiTab.rush,
+  ];
+  int _tab = 0;
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      backgroundColor: const Color(0xFF0F172A),
+      body: SafeArea(
+        child: Column(
+          children: [
+            Padding(
+              padding: const EdgeInsets.fromLTRB(16, 10, 16, 12),
+              child: Row(
+                children: [
+                  GestureDetector(
+                    onTap: Get.back,
+                    child: Container(
+                      width: 40,
+                      height: 40,
+                      decoration: BoxDecoration(
+                        color: Colors.white.withValues(alpha: 0.18),
+                        shape: BoxShape.circle,
+                      ),
+                      child: const Icon(Icons.arrow_back_rounded, color: Colors.white),
+                    ),
+                  ),
+                  const SizedBox(width: 10),
+                  Expanded(
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        const Text('জাপানিজে হাই-হ্যালো',
+                            style: TextStyle(
+                                color: Colors.white, fontWeight: FontWeight.w900, fontSize: 18)),
+                        Text('দৈনন্দিন জাপানি বাক্য: Japanese -> বাংলা',
+                            style: TextStyle(
+                                color: Colors.white.withValues(alpha: 0.74),
+                                fontWeight: FontWeight.w600,
+                                fontSize: 12)),
+                      ],
+                    ),
+                  ),
+                ],
+              ),
+            ),
+            Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 16),
+              child: _HiTabPills(index: _tab, onChange: (i) => setState(() => _tab = i)),
+            ),
+            const SizedBox(height: 10),
+            Expanded(
+              child: AnimatedSwitcher(
+                duration: const Duration(milliseconds: 220),
+                child: switch (_tabs[_tab]) {
+                  _HiTab.flashcard => const _HiFlashGame(key: ValueKey('hiFlash')),
+                  _HiTab.quiz => const _HiQuizGame(key: ValueKey('hiQuiz')),
+                  _HiTab.match => const _HiMatchGame(key: ValueKey('hiMatch')),
+                  _HiTab.rush => const _HiRushGame(key: ValueKey('hiRush')),
+                  _HiTab.listen => const _HiListenGame(key: ValueKey('hiListen')),
+                  _HiTab.read => const _HiReadGame(key: ValueKey('hiRead')),
+                  _HiTab.speak => const _HiSpeakGame(key: ValueKey('hiSpeak')),
+                },
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _Phrase {
+  const _Phrase({required this.jp, required this.romaji, required this.bnPronunciation, required this.bn});
+  final String jp;
+  final String romaji;
+  final String bnPronunciation;
+  final String bn;
+}
+
+const _phrases = <_Phrase>[
+  _Phrase(jp: 'おはよう', romaji: 'ohayou', bnPronunciation: 'ওহাইও', bn: 'সুপ্রভাত'),
+  _Phrase(jp: 'こんにちは', romaji: 'konnichiwa', bnPronunciation: 'কোন্নিচিওয়া', bn: 'হ্যালো / শুভ দুপুর'),
+  _Phrase(jp: 'こんばんは', romaji: 'konbanwa', bnPronunciation: 'কোনবানওয়া', bn: 'শুভ সন্ধ্যা'),
+  _Phrase(jp: 'ありがとう', romaji: 'arigatou', bnPronunciation: 'আরিগাতো', bn: 'ধন্যবাদ'),
+  _Phrase(jp: 'すみません', romaji: 'sumimasen', bnPronunciation: 'সুমিমাসেন', bn: 'মাফ করবেন'),
+  _Phrase(jp: 'ごめんなさい', romaji: 'gomennasai', bnPronunciation: 'গোমেন নাসাই', bn: 'দুঃখিত'),
+  _Phrase(jp: 'はい', romaji: 'hai', bnPronunciation: 'হাই', bn: 'হ্যাঁ'),
+  _Phrase(jp: 'いいえ', romaji: 'iie', bnPronunciation: 'ইইয়ে', bn: 'না'),
+  _Phrase(jp: 'またね', romaji: 'matane', bnPronunciation: 'মাতানে', bn: 'আবার দেখা হবে'),
+  _Phrase(jp: 'さようなら', romaji: 'sayounara', bnPronunciation: 'সায়োনারা', bn: 'বিদায়'),
+];
+
+// ─── Time-of-day greetings (used by শুনে বলো / পড়ে বলো / বলে দেখাও) ──
+class _TimeGreeting {
+  const _TimeGreeting({
+    required this.id,
+    required this.jp,
+    required this.romaji,
+    required this.bnPron,
+    required this.bnMeaning,
+    required this.timeLabel,
+    required this.icon,
+    required this.color,
+  });
+  final int id;
+  final String jp;
+  final String romaji;
+  final String bnPron;
+  final String bnMeaning;
+  final String timeLabel;
+  final IconData icon;
+  final Color color;
+}
+
+const _timeGreetings = <_TimeGreeting>[
+  _TimeGreeting(
+    id: 0,
+    jp: 'おはようございます',
+    romaji: 'ohayou gozaimasu',
+    bnPron: 'ওহাইও গোজাইমাস',
+    bnMeaning: 'শুভ সকাল',
+    timeLabel: 'সকাল',
+    icon: Icons.wb_sunny_rounded,
+    color: Color(0xFFFBBF24),
+  ),
+  _TimeGreeting(
+    id: 1,
+    jp: 'こんにちは',
+    romaji: 'konnichiwa',
+    bnPron: 'কোন্নিচিওয়া',
+    bnMeaning: 'শুভ দুপুর',
+    timeLabel: 'দুপুর',
+    icon: Icons.wb_twilight_rounded,
+    color: Color(0xFFF97316),
+  ),
+  _TimeGreeting(
+    id: 2,
+    jp: 'こんばんは',
+    romaji: 'konbanwa',
+    bnPron: 'কোনবানওয়া',
+    bnMeaning: 'শুভ সন্ধ্যা',
+    timeLabel: 'সন্ধ্যা',
+    icon: Icons.nights_stay_rounded,
+    color: Color(0xFFA855F7),
+  ),
+  _TimeGreeting(
+    id: 3,
+    jp: 'おやすみなさい',
+    romaji: 'oyasumi nasai',
+    bnPron: 'ওইয়াসুমি নাসাই',
+    bnMeaning: 'শুভ রাত্রি',
+    timeLabel: 'রাত',
+    icon: Icons.bedtime_rounded,
+    color: Color(0xFF3B82F6),
+  ),
+];
+
+// Read-game scenarios. answerId references _timeGreetings.id.
+class _ReadScenario {
+  const _ReadScenario({
+    required this.scene,
+    required this.icon,
+    required this.color,
+    required this.answerId,
+    this.trick,
+  });
+  final String scene;
+  final IconData icon;
+  final Color color;
+  final int answerId;
+  final String? trick;
+}
+
+const _readScenarios = <_ReadScenario>[
+  _ReadScenario(
+    scene: 'সকাল ৮টা — কী বলবেন?',
+    icon: Icons.wb_sunny_rounded,
+    color: Color(0xFFFBBF24),
+    answerId: 0,
+  ),
+  _ReadScenario(
+    scene: 'দুপুর ১২টা (সাধারণ) — কী বলবেন?',
+    icon: Icons.wb_twilight_rounded,
+    color: Color(0xFFF97316),
+    answerId: 1,
+  ),
+  _ReadScenario(
+    scene: 'অফিসে সহকর্মীর সাথে দিনের প্রথম দেখা (দুপুর ১টা) — কী বলবেন?',
+    icon: Icons.business_center_rounded,
+    color: Color(0xFFFBBF24),
+    answerId: 0,
+    trick: 'অফিসের নিয়ম: দিনের প্রথম দেখায় সবসময় Ohayo gozaimasu!',
+  ),
+  _ReadScenario(
+    scene: 'সূর্যাস্তের পর / সন্ধ্যা ৭টা — কী বলবেন?',
+    icon: Icons.nights_stay_rounded,
+    color: Color(0xFFA855F7),
+    answerId: 2,
+  ),
+  _ReadScenario(
+    scene: 'ঘুমাতে যাওয়ার আগে — কী বলবেন?',
+    icon: Icons.bedtime_rounded,
+    color: Color(0xFF3B82F6),
+    answerId: 3,
+  ),
+  _ReadScenario(
+    scene: 'অফিসে বসের সাথে বিকাল ৩টায় প্রথম দেখা — কী বলবেন?',
+    icon: Icons.business_center_rounded,
+    color: Color(0xFFFBBF24),
+    answerId: 0,
+    trick: 'বিকেলেও অফিসে প্রথম দেখায় Ohayo gozaimasu!',
+  ),
+];
+
+class _HiTabPills extends StatelessWidget {
+  const _HiTabPills({required this.index, required this.onChange});
+  final int index;
+  final ValueChanged<int> onChange;
+
+  @override
+  Widget build(BuildContext context) {
+    const labels = [
+      'শুনে বলো',
+      'পড়ে বলো',
+      'বলে দেখাও',
+      'ফ্ল্যাশকার্ড',
+      'কুইজ রান',
+      'ফ্রেজ ম্যাচ',
+      'রাশ বস',
+    ];
+    return Container(
+      padding: const EdgeInsets.all(6),
+      decoration: BoxDecoration(
+        color: const Color(0xFF1E293B),
+        borderRadius: BorderRadius.circular(14),
+        border: Border.all(color: Colors.white.withValues(alpha: 0.08)),
+      ),
+      child: SingleChildScrollView(
+        scrollDirection: Axis.horizontal,
+        child: Row(
+          children: [
+            for (var i = 0; i < labels.length; i++) ...[
+              GestureDetector(
+                onTap: () => onChange(i),
+                child: AnimatedContainer(
+                  duration: const Duration(milliseconds: 180),
+                  padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 10),
+                  decoration: BoxDecoration(
+                    color: i == index ? const Color(0xFF3B82F6) : Colors.transparent,
+                    borderRadius: BorderRadius.circular(10),
+                  ),
+                  child: Text(labels[i],
+                      style: const TextStyle(
+                          color: Colors.white, fontWeight: FontWeight.w900, fontSize: 12)),
+                ),
+              ),
+              if (i != labels.length - 1) const SizedBox(width: 6),
+            ]
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _HiFlashGame extends StatefulWidget {
+  const _HiFlashGame({super.key});
+  @override
+  State<_HiFlashGame> createState() => _HiFlashGameState();
+}
+
+class _HiFlashGameState extends State<_HiFlashGame>
+    with TickerProviderStateMixin {
+  final _tts = FlutterTts();
+  late ConfettiController _confetti;
+  bool _ttsReady = false;
+  bool _slowMode = false;
+  int _index = 0;
+  bool _front = true;
+  double _flipTurns = 0;
+  int _xp = 0;
+  int _flips = 0;
+  final Set<int> _seen = {};
+  bool _doneShown = false;
+
+  _Phrase get _item => _phrases[_index];
+
+  @override
+  void initState() {
+    super.initState();
+    _confetti = ConfettiController(duration: const Duration(milliseconds: 700));
+    _initTts();
+    _seen.add(0);
+  }
+
+  Future<void> _initTts() async {
+    try {
+      await _tts.setLanguage('ja-JP');
+      await _tts.setSpeechRate(_slowMode ? 0.32 : 0.50);
+      await _tts.setPitch(1.05);
+      if (!mounted) return;
+      setState(() => _ttsReady = true);
+    } catch (_) {}
+  }
+
+  Future<void> _speak() async {
+    if (!_ttsReady) return;
+    await _tts.stop();
+    await _tts.setSpeechRate(_slowMode ? 0.32 : 0.50);
+    await _tts.speak(_item.jp);
+  }
+
+  void _flip() {
+    HapticFeedback.selectionClick();
+    setState(() {
+      _front = !_front;
+      _flipTurns += math.pi;
+      _flips += 1;
+      _seen.add(_index);
+    });
+    if (!_front) {
+      // ignore: discarded_futures
+      _speak();
+    }
+  }
+
+  void _go(int delta) {
+    final next = (_index + delta).clamp(0, _phrases.length - 1);
+    if (next == _index) return;
+    HapticFeedback.lightImpact();
+    setState(() {
+      _index = next;
+      _front = true;
+      _flipTurns = 0;
+      if (_seen.add(_index)) _xp += 10;
+    });
+    if (_seen.length == _phrases.length && !_doneShown) {
+      _doneShown = true;
+      _confetti.play();
+      HapticFeedback.mediumImpact();
+    }
+    // ignore: discarded_futures
+    _speak();
+  }
+
+  @override
+  void dispose() {
+    _confetti.dispose();
+    _tts.stop();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final progress = _seen.length / _phrases.length;
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(16, 0, 16, 16),
+      child: Stack(
+        clipBehavior: Clip.none,
+        children: [
+          Align(
+            alignment: Alignment.topCenter,
+            child: IgnorePointer(
+              child: SizedBox(
+                height: 130,
+                width: double.infinity,
+                child: ConfettiWidget(
+                  confettiController: _confetti,
+                  blastDirectionality: BlastDirectionality.explosive,
+                  maxBlastForce: 14,
+                  minBlastForce: 6,
+                  emissionFrequency: 0.08,
+                  numberOfParticles: 12,
+                  gravity: 0.22,
+                  shouldLoop: false,
+                  colors: const [
+                    Color(0xFFFFE000),
+                    Color(0xFF10B981),
+                    Color(0xFFFF8A34),
+                    Color(0xFF3B82F6),
+                  ],
+                ),
+              ),
+            ),
+          ),
+          Column(
+            children: [
+              Container(
+                width: double.infinity,
+                padding: const EdgeInsets.all(14),
+                decoration: _deco(),
+                child: Column(
+                  children: [
+                    Row(
+                      children: [
+                        const Icon(Icons.style_rounded, color: Color(0xFFFFE000)),
+                        const SizedBox(width: 8),
+                        Text('কার্ড ${_index + 1}/${_phrases.length}',
+                            style: const TextStyle(
+                                color: Colors.white, fontWeight: FontWeight.w900)),
+                        const SizedBox(width: 10),
+                        _HiStatChip(label: 'XP', value: '$_xp'),
+                        const Spacer(),
+                        OutlinedButton(
+                          onPressed: _seen.isEmpty
+                              ? null
+                              : () => _showHiAwesomeResult(
+                                    context: context,
+                                    title: 'ফ্ল্যাশকার্ড — রিভিউ',
+                                    scoreLabel: 'XP: $_xp',
+                                    stats: [
+                                      'কার্ড দেখা: ${_seen.length}/${_phrases.length}',
+                                      'ফ্লিপ: $_flips',
+                                    ],
+                                    missed: const [],
+                                    onPlayAgain: () {
+                                      setState(() {
+                                        _xp = 0;
+                                        _flips = 0;
+                                        _seen.clear();
+                                        _seen.add(0);
+                                        _index = 0;
+                                        _front = true;
+                                        _flipTurns = 0;
+                                        _doneShown = false;
+                                      });
+                                    },
+                                  ),
+                          style: OutlinedButton.styleFrom(
+                            foregroundColor: Colors.white,
+                            side: BorderSide(
+                                color: Colors.white.withValues(alpha: 0.22)),
+                          ),
+                          child: const Text('রিভিউ',
+                              style: TextStyle(fontWeight: FontWeight.w900)),
+                        ),
+                      ],
+                    ),
+                    const SizedBox(height: 8),
+                    LinearProgressIndicator(
+                      minHeight: 7,
+                      borderRadius: BorderRadius.circular(99),
+                      value: progress.clamp(0, 1),
+                      backgroundColor: Colors.white.withValues(alpha: 0.12),
+                      valueColor:
+                          const AlwaysStoppedAnimation(Color(0xFFFFE000)),
+                    ),
+                  ],
+                ),
+              ),
+              const SizedBox(height: 10),
+              Expanded(
+                child: GestureDetector(
+                  onTap: _flip,
+                  child: Container(
+                    width: double.infinity,
+                    decoration: _deco(radius: 22),
+                    child: Stack(
+                      children: [
+                        Center(
+                          child: AnimatedSwitcher(
+                            duration: const Duration(milliseconds: 280),
+                            switchInCurve: Curves.easeOutCubic,
+                            switchOutCurve: Curves.easeIn,
+                            transitionBuilder: (child, anim) {
+                              return FadeTransition(
+                                opacity: anim,
+                                child: ScaleTransition(
+                                  scale: Tween<double>(begin: 0.94, end: 1.0)
+                                      .animate(CurvedAnimation(
+                                          parent: anim,
+                                          curve: Curves.easeOutCubic)),
+                                  child: child,
+                                ),
+                              );
+                            },
+                            child: _HiFlipFace(
+                              key: ValueKey(_index),
+                              item: _item,
+                              turns: _flipTurns,
+                            ),
+                          ),
+                        ),
+                        Positioned(
+                          top: 10,
+                          right: 10,
+                          child: Row(
+                            children: [
+                              GestureDetector(
+                                onTap: () async {
+                                  setState(() => _slowMode = !_slowMode);
+                                  await _speak();
+                                },
+                                child: Container(
+                                  padding: const EdgeInsets.all(8),
+                                  decoration: BoxDecoration(
+                                    color: _slowMode
+                                        ? const Color(0xFFFFE000)
+                                        : Colors.white.withValues(alpha: 0.12),
+                                    shape: BoxShape.circle,
+                                    border: Border.all(
+                                        color: Colors.white
+                                            .withValues(alpha: 0.2)),
+                                  ),
+                                  child: Icon(Icons.pets_rounded,
+                                      size: 18,
+                                      color: _slowMode
+                                          ? const Color(0xFF1E293B)
+                                          : Colors.white),
+                                ),
+                              ),
+                              const SizedBox(width: 8),
+                              GestureDetector(
+                                onTap: _speak,
+                                child: Container(
+                                  padding: const EdgeInsets.all(8),
+                                  decoration: BoxDecoration(
+                                    color: const Color(0xFFFFE000)
+                                        .withValues(alpha: 0.22),
+                                    shape: BoxShape.circle,
+                                    border: Border.all(
+                                        color: const Color(0xFFFFE000)
+                                            .withValues(alpha: 0.6)),
+                                  ),
+                                  child: const Icon(Icons.volume_up_rounded,
+                                      size: 18, color: Color(0xFFFFE000)),
+                                ),
+                              ),
+                            ],
+                          ),
+                        ),
+                        Positioned(
+                          bottom: 10,
+                          left: 0,
+                          right: 0,
+                          child: Center(
+                            child: Text(
+                              _front
+                                  ? 'কার্ডে ট্যাপ করে অর্থ দেখো'
+                                  : 'কার্ডে ট্যাপ করে আবার ঘোরাও',
+                              style: TextStyle(
+                                  color: Colors.white.withValues(alpha: 0.55),
+                                  fontWeight: FontWeight.w700,
+                                  fontSize: 11),
+                            ),
+                          ),
+                        ),
+                      ],
+                    ),
+                  ),
+                ),
+              ),
+              const SizedBox(height: 10),
+              Row(
+                children: [
+                  Expanded(
+                    child: OutlinedButton.icon(
+                      onPressed: _index == 0 ? null : () => _go(-1),
+                      style: OutlinedButton.styleFrom(
+                          side: BorderSide(
+                              color: Colors.white.withValues(alpha: 0.2)),
+                          foregroundColor: Colors.white),
+                      icon: const Icon(Icons.navigate_before_rounded),
+                      label: const Text('আগেরটি',
+                          style: TextStyle(fontWeight: FontWeight.w900)),
+                    ),
+                  ),
+                  const SizedBox(width: 10),
+                  Expanded(
+                    child: ElevatedButton.icon(
+                      onPressed: _index >= _phrases.length - 1
+                          ? null
+                          : () => _go(1),
+                      style: ElevatedButton.styleFrom(
+                        backgroundColor: const Color(0xFF3B82F6),
+                        foregroundColor: Colors.white,
+                      ),
+                      icon: const Icon(Icons.navigate_next_rounded),
+                      label: const Text('পরেরটি',
+                          style: TextStyle(fontWeight: FontWeight.w900)),
+                    ),
+                  ),
+                ],
+              ),
+            ],
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _HiQuizGame extends StatefulWidget {
+  const _HiQuizGame({super.key});
+  @override
+  State<_HiQuizGame> createState() => _HiQuizGameState();
+}
+
+class _HiQuizGameState extends State<_HiQuizGame>
+    with TickerProviderStateMixin {
+  final _rng = math.Random();
+  final _tts = FlutterTts();
+  late ConfettiController _confetti;
+  late AnimationController _shakeCtrl;
+  bool _ttsReady = false;
+  bool _slowMode = false;
+
+  late _Phrase _target;
+  late List<_Phrase> _options;
+  int _score = 0;
+  int _streak = 0;
+  int _bestStreak = 0;
+  int _attempts = 0;
+  int _correct = 0;
+  final Map<String, int> _missed = {};
+  bool _locked = false;
+  String? _picked;
+
+  @override
+  void initState() {
+    super.initState();
+    _confetti = ConfettiController(duration: const Duration(milliseconds: 650));
+    _shakeCtrl = AnimationController(
+        vsync: this, duration: const Duration(milliseconds: 380));
+    _initTts();
+    _next(speak: false);
+  }
+
+  Future<void> _initTts() async {
+    try {
+      await _tts.setLanguage('ja-JP');
+      await _tts.setSpeechRate(_slowMode ? 0.32 : 0.50);
+      await _tts.setPitch(1.05);
+      if (!mounted) return;
+      setState(() => _ttsReady = true);
+      // ignore: discarded_futures
+      _speak();
+    } catch (_) {}
+  }
+
+  Future<void> _speak() async {
+    if (!_ttsReady) return;
+    await _tts.stop();
+    await _tts.setSpeechRate(_slowMode ? 0.32 : 0.50);
+    await _tts.speak(_target.jp);
+  }
+
+  void _next({bool speak = true}) {
+    final t = _phrases[_rng.nextInt(_phrases.length)];
+    final pool = _phrases.where((e) => e.jp != t.jp).toList()..shuffle(_rng);
+    setState(() {
+      _target = t;
+      _options = [t, ...pool.take(3)]..shuffle(_rng);
+      _locked = false;
+      _picked = null;
+    });
+    if (speak && _ttsReady) {
+      // ignore: discarded_futures
+      _speak();
+    }
+  }
+
+  void _pick(_Phrase p) {
+    if (_locked) return;
+    final ok = p.jp == _target.jp;
+    setState(() {
+      _locked = true;
+      _picked = p.jp;
+      _attempts += 1;
+      if (ok) {
+        _streak += 1;
+        if (_streak > _bestStreak) _bestStreak = _streak;
+        _score += 10;
+        _correct += 1;
+      } else {
+        _streak = 0;
+        _missed[_target.jp] = (_missed[_target.jp] ?? 0) + 1;
+      }
+    });
+    if (ok) {
+      HapticFeedback.mediumImpact();
+      _confetti.play();
+    } else {
+      HapticFeedback.heavyImpact();
+      _shakeCtrl.forward(from: 0);
+    }
+    Future.delayed(const Duration(milliseconds: 620), () {
+      if (!mounted) return;
+      _next();
+    });
+  }
+
+  @override
+  void dispose() {
+    _confetti.dispose();
+    _shakeCtrl.dispose();
+    _tts.stop();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(16, 0, 16, 16),
+      child: Stack(
+        clipBehavior: Clip.none,
+        children: [
+          Align(
+            alignment: Alignment.topCenter,
+            child: IgnorePointer(
+              child: SizedBox(
+                height: 130,
+                width: double.infinity,
+                child: ConfettiWidget(
+                  confettiController: _confetti,
+                  blastDirectionality: BlastDirectionality.explosive,
+                  maxBlastForce: 14,
+                  minBlastForce: 6,
+                  emissionFrequency: 0.08,
+                  numberOfParticles: 12,
+                  gravity: 0.22,
+                  shouldLoop: false,
+                  colors: const [
+                    Color(0xFFFFE000),
+                    Color(0xFF10B981),
+                    Color(0xFFFF8A34),
+                    Color(0xFF3B82F6),
+                  ],
+                ),
+              ),
+            ),
+          ),
+          Column(children: [
+            Container(
+              width: double.infinity,
+              padding: const EdgeInsets.all(14),
+              decoration: _deco(),
+              child: Row(
+                children: [
+                  const Icon(Icons.bolt_rounded, color: Color(0xFFFFE000)),
+                  const SizedBox(width: 8),
+                  Text('স্কোর: $_score',
+                      style: const TextStyle(
+                          color: Colors.white, fontWeight: FontWeight.w900)),
+                  const SizedBox(width: 10),
+                  _HiStatChip(label: 'স্ট্রিক', value: '$_streak'),
+                  const SizedBox(width: 6),
+                  _HiStatChip(label: 'সেরা', value: '$_bestStreak'),
+                  const Spacer(),
+                  OutlinedButton(
+                    onPressed: _attempts == 0
+                        ? null
+                        : () => _showHiAwesomeResult(
+                              context: context,
+                              title: 'কুইজ রান — রিভিউ',
+                              scoreLabel: 'স্কোর: $_score',
+                              stats: [
+                                'চেষ্টা: $_attempts',
+                                'সঠিক: $_correct',
+                                'নির্ভুলতা: ${((_correct * 100) / _attempts).round()}%',
+                                'সেরা স্ট্রিক: $_bestStreak',
+                              ],
+                              missed: _missed.entries.toList()
+                                ..sort((a, b) => b.value.compareTo(a.value)),
+                              onPlayAgain: () {
+                                setState(() {
+                                  _score = 0;
+                                  _streak = 0;
+                                  _bestStreak = 0;
+                                  _attempts = 0;
+                                  _correct = 0;
+                                  _missed.clear();
+                                });
+                                _next();
+                              },
+                            ),
+                    style: OutlinedButton.styleFrom(
+                      foregroundColor: Colors.white,
+                      side: BorderSide(
+                          color: Colors.white.withValues(alpha: 0.22)),
+                    ),
+                    child: const Text('রিভিউ',
+                        style: TextStyle(fontWeight: FontWeight.w900)),
+                  ),
+                ],
+              ),
+            ),
+            const SizedBox(height: 10),
+            AnimatedBuilder(
+              animation: _shakeCtrl,
+              builder: (_, child) {
+                final wrong = _picked != null && _picked != _target.jp;
+                final dx = wrong
+                    ? math.sin(_shakeCtrl.value * math.pi * 6) * 8
+                    : 0.0;
+                return Transform.translate(
+                    offset: Offset(dx, 0), child: child);
+              },
+              child: Container(
+                width: double.infinity,
+                padding: const EdgeInsets.all(16),
+                decoration: _deco(radius: 18),
+                child: Column(
+                  children: [
+                    const Text('এই জাপানি বাক্যের বাংলা মানে কোনটি?',
+                        textAlign: TextAlign.center,
+                        style: TextStyle(
+                            color: Colors.white, fontWeight: FontWeight.w900)),
+                    const SizedBox(height: 10),
+                    Text(_target.jp,
+                        style: const TextStyle(
+                            color: Color(0xFFFFE000),
+                            fontSize: 40,
+                            fontWeight: FontWeight.w900)),
+                    const SizedBox(height: 4),
+                    Text(_target.romaji,
+                        style: TextStyle(
+                            color: Colors.white.withValues(alpha: 0.8),
+                            fontWeight: FontWeight.w700)),
+                    const SizedBox(height: 4),
+                    Text('উচ্চারণ: ${_target.bnPronunciation}',
+                        style: TextStyle(
+                            color: Colors.white.withValues(alpha: 0.85),
+                            fontWeight: FontWeight.w700)),
+                    const SizedBox(height: 10),
+                    Row(
+                      mainAxisAlignment: MainAxisAlignment.center,
+                      children: [
+                        GestureDetector(
+                          onTap: _speak,
+                          child: Container(
+                            padding: const EdgeInsets.symmetric(
+                                horizontal: 14, vertical: 8),
+                            decoration: BoxDecoration(
+                              color: const Color(0xFFFFE000)
+                                  .withValues(alpha: 0.18),
+                              borderRadius: BorderRadius.circular(99),
+                              border: Border.all(
+                                  color: const Color(0xFFFFE000)
+                                      .withValues(alpha: 0.6)),
+                            ),
+                            child: const Row(
+                              mainAxisSize: MainAxisSize.min,
+                              children: [
+                                Icon(Icons.volume_up_rounded,
+                                    color: Color(0xFFFFE000), size: 18),
+                                SizedBox(width: 6),
+                                Text('শুনি',
+                                    style: TextStyle(
+                                        color: Color(0xFFFFE000),
+                                        fontWeight: FontWeight.w900)),
+                              ],
+                            ),
+                          ),
+                        ),
+                        const SizedBox(width: 10),
+                        GestureDetector(
+                          onTap: () async {
+                            setState(() => _slowMode = !_slowMode);
+                            await _speak();
+                          },
+                          child: Container(
+                            padding: const EdgeInsets.symmetric(
+                                horizontal: 14, vertical: 8),
+                            decoration: BoxDecoration(
+                              color: _slowMode
+                                  ? const Color(0xFFFFE000)
+                                  : Colors.white.withValues(alpha: 0.10),
+                              borderRadius: BorderRadius.circular(99),
+                              border: Border.all(
+                                  color: Colors.white.withValues(alpha: 0.2)),
+                            ),
+                            child: Row(
+                              mainAxisSize: MainAxisSize.min,
+                              children: [
+                                Icon(Icons.pets_rounded,
+                                    color: _slowMode
+                                        ? const Color(0xFF1E293B)
+                                        : Colors.white,
+                                    size: 18),
+                                const SizedBox(width: 6),
+                                Text('ধীরে',
+                                    style: TextStyle(
+                                        color: _slowMode
+                                            ? const Color(0xFF1E293B)
+                                            : Colors.white,
+                                        fontWeight: FontWeight.w900)),
+                              ],
+                            ),
+                          ),
+                        ),
+                      ],
+                    ),
+                  ],
+                ),
+              ),
+            ),
+            const SizedBox(height: 10),
+            Expanded(
+              child: ListView.separated(
+                itemCount: _options.length,
+                separatorBuilder: (_, __) => const SizedBox(height: 10),
+                itemBuilder: (_, i) {
+                  final o = _options[i];
+                  final picked = _picked == o.jp;
+                  final correct = o.jp == _target.jp;
+                  final bg = _picked == null
+                      ? Colors.white.withValues(alpha: 0.06)
+                      : (correct
+                          ? const Color(0xFF10B981).withValues(alpha: 0.22)
+                          : (picked
+                              ? const Color(0xFFEF4444).withValues(alpha: 0.22)
+                              : Colors.white.withValues(alpha: 0.05)));
+                  final border = _picked == null
+                      ? Colors.white.withValues(alpha: 0.16)
+                      : (correct
+                          ? const Color(0xFF10B981)
+                          : (picked
+                              ? const Color(0xFFEF4444)
+                              : Colors.white.withValues(alpha: 0.16)));
+                  return GestureDetector(
+                    onTap: () => _pick(o),
+                    child: AnimatedScale(
+                      scale: picked && correct ? 1.03 : 1.0,
+                      duration: const Duration(milliseconds: 220),
+                      child: Container(
+                        padding: const EdgeInsets.all(14),
+                        decoration: BoxDecoration(
+                          color: bg,
+                          borderRadius: BorderRadius.circular(14),
+                          border: Border.all(
+                              color: border, width: _picked == null ? 1 : 2),
+                        ),
+                        child: Row(
+                          children: [
+                            if (picked || (correct && _picked != null))
+                              Padding(
+                                padding: const EdgeInsets.only(right: 8),
+                                child: Icon(
+                                  correct
+                                      ? Icons.check_circle_rounded
+                                      : Icons.cancel_rounded,
+                                  color: correct
+                                      ? const Color(0xFF10B981)
+                                      : const Color(0xFFEF4444),
+                                  size: 20,
+                                ),
+                              ),
+                            Expanded(
+                              child: Text(o.bn,
+                                  style: const TextStyle(
+                                      color: Colors.white,
+                                      fontWeight: FontWeight.w900,
+                                      fontSize: 18)),
+                            ),
+                          ],
+                        ),
+                      ),
+                    ),
+                  );
+                },
+              ),
+            ),
+          ]),
+        ],
+      ),
+    );
+  }
+}
+
+class _HiPair {
+  const _HiPair({required this.keyId, required this.label});
+  final String keyId;
+  final String label;
+}
+
+class _HiMatchGame extends StatefulWidget {
+  const _HiMatchGame({super.key});
+  @override
+  State<_HiMatchGame> createState() => _HiMatchGameState();
+}
+
+class _HiMatchGameState extends State<_HiMatchGame>
+    with TickerProviderStateMixin {
+  final _rng = math.Random();
+  final _tts = FlutterTts();
+  late ConfettiController _confetti;
+  late AnimationController _shakeCtrl;
+  bool _ttsReady = false;
+
+  late List<_HiPair> _jpColumn;
+  late List<_HiPair> _bnColumn;
+  int? _selectedJpIdx;
+  int? _selectedBnIdx;
+  final _matchedKeys = <String>{};
+  int _moves = 0;
+  int _wrongJp = -1;
+  int _wrongBn = -1;
+  int _wrongMoves = 0;
+  int _streak = 0;
+  int _bestStreak = 0;
+  int _xp = 0;
+  final Map<String, int> _missesByKey = {};
+  final Stopwatch _stopwatch = Stopwatch();
+  Timer? _ticker;
+
+  @override
+  void initState() {
+    super.initState();
+    _confetti = ConfettiController(duration: const Duration(milliseconds: 700));
+    _shakeCtrl = AnimationController(
+        vsync: this, duration: const Duration(milliseconds: 380));
+    _initTts();
+    _reset();
+  }
+
+  Future<void> _initTts() async {
+    try {
+      await _tts.setLanguage('ja-JP');
+      await _tts.setSpeechRate(0.50);
+      await _tts.setPitch(1.05);
+      if (!mounted) return;
+      setState(() => _ttsReady = true);
+    } catch (_) {}
+  }
+
+  Future<void> _speak(String jp) async {
+    if (!_ttsReady) return;
+    await _tts.stop();
+    await _tts.speak(jp);
+  }
+
+  String _formatDuration(Duration d) {
+    final m = d.inMinutes.remainder(60).toString().padLeft(2, '0');
+    final s = d.inSeconds.remainder(60).toString().padLeft(2, '0');
+    return '$m:$s';
+  }
+
+  void _reset() {
+    final take = List<_Phrase>.of(_phrases)..shuffle(_rng);
+    final six = take.take(6).toList();
+    final jp = <_HiPair>[];
+    final bn = <_HiPair>[];
+    for (final p in six) {
+      jp.add(_HiPair(keyId: p.jp, label: '${p.jp}\n(${p.bnPronunciation})'));
+      bn.add(_HiPair(keyId: p.jp, label: p.bn));
+    }
+    jp.shuffle(_rng);
+    bn.shuffle(_rng);
+    setState(() {
+      _jpColumn = jp;
+      _bnColumn = bn;
+      _selectedJpIdx = null;
+      _selectedBnIdx = null;
+      _matchedKeys.clear();
+      _missesByKey.clear();
+      _moves = 0;
+      _wrongJp = -1;
+      _wrongBn = -1;
+      _wrongMoves = 0;
+      _streak = 0;
+      _bestStreak = 0;
+      _xp = 0;
+    });
+    _stopwatch
+      ..reset()
+      ..start();
+    _ticker?.cancel();
+    _ticker = Timer.periodic(const Duration(seconds: 1), (_) {
+      if (mounted) setState(() {});
+    });
+  }
+
+  void _tapJp(int idx) {
+    final key = _jpColumn[idx].keyId;
+    if (_matchedKeys.contains(key)) return;
+    HapticFeedback.selectionClick();
+    // ignore: discarded_futures
+    _speak(key);
+    setState(() {
+      _wrongJp = -1;
+      _wrongBn = -1;
+      _selectedJpIdx = idx;
+    });
+    _tryMatch();
+  }
+
+  void _tapBn(int idx) {
+    final key = _bnColumn[idx].keyId;
+    if (_matchedKeys.contains(key)) return;
+    HapticFeedback.selectionClick();
+    setState(() {
+      _wrongJp = -1;
+      _wrongBn = -1;
+      _selectedBnIdx = idx;
+    });
+    _tryMatch();
+  }
+
+  void _tryMatch() {
+    if (_selectedJpIdx == null || _selectedBnIdx == null) return;
+    _moves += 1;
+    final jp = _jpColumn[_selectedJpIdx!];
+    final bn = _bnColumn[_selectedBnIdx!];
+    final ok = jp.keyId == bn.keyId;
+    if (ok) {
+      HapticFeedback.mediumImpact();
+      setState(() {
+        _matchedKeys.add(jp.keyId);
+        _selectedJpIdx = null;
+        _selectedBnIdx = null;
+        _streak += 1;
+        if (_streak > _bestStreak) _bestStreak = _streak;
+        _xp += 10;
+      });
+      _confetti.play();
+      if (_matchedKeys.length == _jpColumn.length) {
+        _stopwatch.stop();
+        _ticker?.cancel();
+        Future.delayed(const Duration(milliseconds: 600), () {
+          if (!mounted) return;
+          _showHiAwesomeResult(
+            context: context,
+            title: 'ফ্রেজ ম্যাচ — সব মিলেছে',
+            scoreLabel: 'XP: $_xp',
+            stats: [
+              'মুভ: $_moves',
+              'ভুল: $_wrongMoves',
+              'নির্ভুলতা: ${_moves == 0 ? 0 : (((_moves - _wrongMoves) * 100) / _moves).round()}%',
+              'সেরা স্ট্রিক: $_bestStreak',
+              'সময়: ${_formatDuration(_stopwatch.elapsed)}',
+            ],
+            missed: _missesByKey.entries.toList()
+              ..sort((a, b) => b.value.compareTo(a.value)),
+            onPlayAgain: _reset,
+          );
+        });
+      }
+      return;
+    }
+    HapticFeedback.heavyImpact();
+    _wrongMoves += 1;
+    _missesByKey[jp.keyId] = (_missesByKey[jp.keyId] ?? 0) + 1;
+    _missesByKey[bn.keyId] = (_missesByKey[bn.keyId] ?? 0) + 1;
+    final wrongJpIdx = _selectedJpIdx!;
+    final wrongBnIdx = _selectedBnIdx!;
+    setState(() {
+      _wrongJp = wrongJpIdx;
+      _wrongBn = wrongBnIdx;
+      _selectedJpIdx = null;
+      _selectedBnIdx = null;
+      _streak = 0;
+    });
+    _shakeCtrl.forward(from: 0);
+    Future.delayed(const Duration(milliseconds: 460), () {
+      if (!mounted) return;
+      setState(() {
+        if (_wrongJp == wrongJpIdx) _wrongJp = -1;
+        if (_wrongBn == wrongBnIdx) _wrongBn = -1;
+      });
+    });
+  }
+
+  @override
+  void dispose() {
+    _confetti.dispose();
+    _shakeCtrl.dispose();
+    _ticker?.cancel();
+    _tts.stop();
+    super.dispose();
+  }
+
+  Widget _buildCard(_HiPair c, int idx, bool isJp) {
+    final selected = isJp ? _selectedJpIdx == idx : _selectedBnIdx == idx;
+    final matched = _matchedKeys.contains(c.keyId);
+    final wrong = isJp ? _wrongJp == idx : _wrongBn == idx;
+    final border = matched
+        ? const Color(0xFF10B981)
+        : (wrong
+            ? const Color(0xFFEF4444)
+            : (selected
+                ? const Color(0xFFFFE000)
+                : Colors.white.withValues(alpha: 0.14)));
+    final bg = matched
+        ? const Color(0xFF10B981).withValues(alpha: 0.17)
+        : (wrong
+            ? const Color(0xFFEF4444).withValues(alpha: 0.14)
+            : (selected
+                ? const Color(0xFFFFE000).withValues(alpha: 0.13)
+                : Colors.white.withValues(alpha: 0.06)));
+    return AnimatedBuilder(
+      animation: _shakeCtrl,
+      builder: (_, child) {
+        final dx = wrong ? math.sin(_shakeCtrl.value * math.pi * 6) * 6 : 0.0;
+        return Transform.translate(offset: Offset(dx, 0), child: child);
+      },
+      child: GestureDetector(
+        onTap: () => isJp ? _tapJp(idx) : _tapBn(idx),
+        child: Container(
+          padding: const EdgeInsets.all(12),
+          decoration: BoxDecoration(
+            color: bg,
+            borderRadius: BorderRadius.circular(14),
+            border: Border.all(color: border, width: selected ? 2.1 : 1.4),
+          ),
+          child: Stack(
+            children: [
+              Center(
+                child: Text(
+                  c.label,
+                  textAlign: TextAlign.center,
+                  style: TextStyle(
+                    color: Colors.white,
+                    fontWeight: FontWeight.w900,
+                    fontSize: isJp ? 20 : 18,
+                    height: 1.2,
+                  ),
+                ),
+              ),
+              if (isJp)
+                Positioned(
+                  top: 2,
+                  right: 2,
+                  child: Container(
+                    padding: const EdgeInsets.all(4),
+                    decoration: BoxDecoration(
+                      color: Colors.white.withValues(alpha: 0.18),
+                      shape: BoxShape.circle,
+                    ),
+                    child: const Icon(Icons.volume_up_rounded,
+                        size: 12, color: Colors.white),
+                  ),
+                ),
+              if (matched)
+                const Positioned(
+                  top: 2,
+                  left: 2,
+                  child: Icon(Icons.check_circle_rounded,
+                      size: 16, color: Color(0xFF10B981)),
+                ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final progress =
+        _jpColumn.isEmpty ? 0.0 : _matchedKeys.length / _jpColumn.length;
+    final elapsed = _formatDuration(_stopwatch.elapsed);
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(16, 0, 16, 16),
+      child: Stack(
+        clipBehavior: Clip.none,
+        children: [
+          Align(
+            alignment: Alignment.topCenter,
+            child: IgnorePointer(
+              child: SizedBox(
+                height: 130,
+                width: double.infinity,
+                child: ConfettiWidget(
+                  confettiController: _confetti,
+                  blastDirectionality: BlastDirectionality.explosive,
+                  maxBlastForce: 14,
+                  minBlastForce: 6,
+                  emissionFrequency: 0.08,
+                  numberOfParticles: 12,
+                  gravity: 0.22,
+                  shouldLoop: false,
+                  colors: const [
+                    Color(0xFFFFE000),
+                    Color(0xFF10B981),
+                    Color(0xFFFF8A34),
+                    Color(0xFF3B82F6),
+                  ],
+                ),
+              ),
+            ),
+          ),
+          Column(children: [
+            Container(
+              padding: const EdgeInsets.all(14),
+              decoration: _deco(),
+              child: Column(
+                children: [
+                  Row(
+                    children: [
+                      const Icon(Icons.link_rounded, color: Color(0xFFFFE000)),
+                      const SizedBox(width: 8),
+                      const Expanded(
+                        child: Text('ফ্রেজ মিলাও',
+                            style: TextStyle(
+                                color: Colors.white,
+                                fontWeight: FontWeight.w900)),
+                      ),
+                      _HiStatChip(label: 'XP', value: '$_xp'),
+                      const SizedBox(width: 6),
+                      _HiStatChip(label: 'স্ট্রিক', value: '$_streak'),
+                    ],
+                  ),
+                  const SizedBox(height: 8),
+                  Row(
+                    children: [
+                      Icon(Icons.timer_rounded,
+                          size: 14,
+                          color: Colors.white.withValues(alpha: 0.7)),
+                      const SizedBox(width: 4),
+                      Text(elapsed,
+                          style: TextStyle(
+                              color: Colors.white.withValues(alpha: 0.85),
+                              fontWeight: FontWeight.w800,
+                              fontSize: 12)),
+                      const SizedBox(width: 14),
+                      Text('মুভ: $_moves',
+                          style: TextStyle(
+                              color: Colors.white.withValues(alpha: 0.85),
+                              fontWeight: FontWeight.w800,
+                              fontSize: 12)),
+                      const Spacer(),
+                      Text(
+                          '${_matchedKeys.length}/${_jpColumn.length} মিলেছে',
+                          style: const TextStyle(
+                              color: Color(0xFFFFE000),
+                              fontWeight: FontWeight.w900,
+                              fontSize: 12)),
+                    ],
+                  ),
+                  const SizedBox(height: 8),
+                  LinearProgressIndicator(
+                    minHeight: 7,
+                    borderRadius: BorderRadius.circular(99),
+                    value: progress.clamp(0, 1),
+                    backgroundColor: Colors.white.withValues(alpha: 0.12),
+                    valueColor:
+                        const AlwaysStoppedAnimation(Color(0xFFFFE000)),
+                  ),
+                ],
+              ),
+            ),
+            const SizedBox(height: 10),
+            Expanded(
+              child: Row(
+                children: [
+                  Expanded(
+                    child: ListView.separated(
+                      physics: const BouncingScrollPhysics(),
+                      itemCount: _jpColumn.length,
+                      separatorBuilder: (_, __) => const SizedBox(height: 10),
+                      itemBuilder: (_, i) =>
+                          _buildCard(_jpColumn[i], i, true),
+                    ),
+                  ),
+                  const SizedBox(width: 10),
+                  Expanded(
+                    child: ListView.separated(
+                      physics: const BouncingScrollPhysics(),
+                      itemCount: _bnColumn.length,
+                      separatorBuilder: (_, __) => const SizedBox(height: 10),
+                      itemBuilder: (_, i) =>
+                          _buildCard(_bnColumn[i], i, false),
+                    ),
+                  ),
+                ],
+              ),
+            ),
+            SizedBox(
+              width: double.infinity,
+              child: OutlinedButton.icon(
+                onPressed: _reset,
+                style: OutlinedButton.styleFrom(
+                    side:
+                        BorderSide(color: Colors.white.withValues(alpha: 0.2)),
+                    foregroundColor: Colors.white),
+                icon: const Icon(Icons.refresh_rounded),
+                label: const Text('রি-স্টার্ট',
+                    style: TextStyle(fontWeight: FontWeight.w900)),
+              ),
+            ),
+          ]),
+        ],
+      ),
+    );
+  }
+}
+
+class _HiRushGame extends StatefulWidget {
+  const _HiRushGame({super.key});
+
+  @override
+  State<_HiRushGame> createState() => _HiRushGameState();
+}
+
+class _HiRushGameState extends State<_HiRushGame>
+    with TickerProviderStateMixin {
+  final _rng = math.Random();
+  final _tts = FlutterTts();
+  late ConfettiController _confetti;
+  late AnimationController _shakeCtrl;
+  Timer? _timer;
+  static const _totalSeconds = 25;
+  static const _sessionXpBonus = 50;
+
+  int _timeLeft = _totalSeconds;
+  int _score = 0;
+  int _streak = 0;
+  int _bestStreak = 0;
+  bool _locked = false;
+  bool? _lastCorrect;
+  int _attempts = 0;
+  int _correct = 0;
+  bool _ttsReady = false;
+  bool _slowMode = false;
+  final Map<String, int> _missed = {};
+  late _Phrase _target;
+  late String _shownMeaning;
+  late bool _isActuallyCorrect;
+
+  @override
+  void initState() {
+    super.initState();
+    _confetti = ConfettiController(duration: const Duration(milliseconds: 650));
+    _shakeCtrl = AnimationController(
+        vsync: this, duration: const Duration(milliseconds: 380));
+    _initTts();
+    _next(speak: false);
+    _startTimer();
+  }
+
+  Future<void> _initTts() async {
+    try {
+      await _tts.setLanguage('ja-JP');
+      await _tts.setSpeechRate(_slowMode ? 0.32 : 0.50);
+      await _tts.setPitch(1.05);
+      if (!mounted) return;
+      setState(() => _ttsReady = true);
+      // ignore: discarded_futures
+      _speak();
+    } catch (_) {}
+  }
+
+  Future<void> _speak() async {
+    if (!_ttsReady) return;
+    await _tts.stop();
+    await _tts.setSpeechRate(_slowMode ? 0.32 : 0.50);
+    await _tts.speak(_target.jp);
+  }
+
+  void _startTimer() {
+    _timer?.cancel();
+    _timer = Timer.periodic(const Duration(seconds: 1), (timer) {
+      if (!mounted) return;
+      if (_timeLeft <= 1) {
+        timer.cancel();
+        _showEnd();
+      } else {
+        setState(() => _timeLeft -= 1);
+      }
+    });
+  }
+
+  void _next({bool speak = true}) {
+    final t = _phrases[_rng.nextInt(_phrases.length)];
+    final showCorrect = _rng.nextBool();
+    String meaning = t.bn;
+    if (!showCorrect) {
+      final wrongPool = _phrases.where((p) => p.jp != t.jp).toList()
+        ..shuffle(_rng);
+      meaning = wrongPool.first.bn;
+    }
+    setState(() {
+      _target = t;
+      _shownMeaning = meaning;
+      _isActuallyCorrect = showCorrect;
+      _locked = false;
+      _lastCorrect = null;
+    });
+    if (speak && _ttsReady) {
+      // ignore: discarded_futures
+      _speak();
+    }
+  }
+
+  void _answer(bool saysCorrect) {
+    if (_locked) return;
+    final ok = saysCorrect == _isActuallyCorrect;
+    setState(() {
+      _locked = true;
+      _lastCorrect = ok;
+      _attempts += 1;
+      if (ok) {
+        _streak += 1;
+        if (_streak > _bestStreak) _bestStreak = _streak;
+        _score += 10;
+        _correct += 1;
+      } else {
+        _streak = 0;
+        _missed[_target.jp] = (_missed[_target.jp] ?? 0) + 1;
+      }
+    });
+    if (ok) {
+      HapticFeedback.mediumImpact();
+      _confetti.play();
+    } else {
+      HapticFeedback.heavyImpact();
+      _shakeCtrl.forward(from: 0);
+    }
+    Future.delayed(const Duration(milliseconds: 480), () {
+      if (!mounted) return;
+      _next();
+    });
+  }
+
+  void _showEnd() {
+    _timer?.cancel();
+    _showHiAwesomeResult(
+      context: context,
+      title: 'রাশ বস — রেজাল্ট',
+      scoreLabel: 'XP: ${_score + _sessionXpBonus}',
+      stats: [
+        'চেষ্টা: $_attempts',
+        'সঠিক: $_correct',
+        'নির্ভুলতা: ${_attempts == 0 ? 0 : ((_correct * 100) / _attempts).round()}%',
+        'সেরা স্ট্রিক: $_bestStreak',
+        'সেশন বোনাস: +$_sessionXpBonus XP',
+      ],
+      missed: _missed.entries.toList()
+        ..sort((a, b) => b.value.compareTo(a.value)),
+      onPlayAgain: () {
+        setState(() {
+          _timeLeft = _totalSeconds;
+          _score = 0;
+          _streak = 0;
+          _bestStreak = 0;
+          _lastCorrect = null;
+          _attempts = 0;
+          _correct = 0;
+          _missed.clear();
+        });
+        _next();
+        _startTimer();
+      },
+    );
+  }
+
+  @override
+  void dispose() {
+    _timer?.cancel();
+    _confetti.dispose();
+    _shakeCtrl.dispose();
+    _tts.stop();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final timeProgress = _timeLeft / _totalSeconds;
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(16, 0, 16, 16),
+      child: Stack(
+        clipBehavior: Clip.none,
+        children: [
+          Align(
+            alignment: Alignment.topCenter,
+            child: IgnorePointer(
+              child: SizedBox(
+                height: 130,
+                width: double.infinity,
+                child: ConfettiWidget(
+                  confettiController: _confetti,
+                  blastDirectionality: BlastDirectionality.explosive,
+                  maxBlastForce: 14,
+                  minBlastForce: 6,
+                  emissionFrequency: 0.08,
+                  numberOfParticles: 12,
+                  gravity: 0.22,
+                  shouldLoop: false,
+                  colors: const [
+                    Color(0xFFFFE000),
+                    Color(0xFF10B981),
+                    Color(0xFFFF8A34),
+                    Color(0xFF3B82F6),
+                  ],
+                ),
+              ),
+            ),
+          ),
+          Column(
+            children: [
+              Container(
+                padding: const EdgeInsets.all(14),
+                decoration: _deco(),
+                child: Column(
+                  children: [
+                    Row(
+                      children: [
+                        Icon(Icons.timer_rounded,
+                            color: _timeLeft <= 5
+                                ? const Color(0xFFFF6B6B)
+                                : const Color(0xFFFFE000)),
+                        const SizedBox(width: 8),
+                        Text('সময়: ${_timeLeft}s',
+                            style: const TextStyle(
+                                color: Colors.white,
+                                fontWeight: FontWeight.w900)),
+                        const Spacer(),
+                        Text('স্কোর: $_score',
+                            style: const TextStyle(
+                                color: Colors.white,
+                                fontWeight: FontWeight.w900)),
+                        const SizedBox(width: 10),
+                        _HiStatChip(label: 'সেরা', value: '$_bestStreak'),
+                      ],
+                    ),
+                    const SizedBox(height: 8),
+                    LinearProgressIndicator(
+                      minHeight: 7,
+                      borderRadius: BorderRadius.circular(99),
+                      value: timeProgress.clamp(0, 1),
+                      backgroundColor: Colors.white.withValues(alpha: 0.12),
+                      valueColor: AlwaysStoppedAnimation(_timeLeft <= 5
+                          ? const Color(0xFFFF6B6B)
+                          : const Color(0xFFFFE000)),
+                    ),
+                  ],
+                ),
+              ),
+              const SizedBox(height: 10),
+              AnimatedBuilder(
+                animation: _shakeCtrl,
+                builder: (_, child) {
+                  final wrong = _lastCorrect == false;
+                  final dx = wrong
+                      ? math.sin(_shakeCtrl.value * math.pi * 6) * 8
+                      : 0.0;
+                  return Transform.translate(
+                      offset: Offset(dx, 0), child: child);
+                },
+                child: Container(
+                  width: double.infinity,
+                  padding: const EdgeInsets.all(18),
+                  decoration: _deco(radius: 20),
+                  child: Column(
+                    children: [
+                      const Text('জাপানি বাক্য আর বাংলা মানে মিলছে?',
+                          style: TextStyle(
+                              color: Colors.white,
+                              fontWeight: FontWeight.w900)),
+                      const SizedBox(height: 10),
+                      Text(_target.jp,
+                          style: const TextStyle(
+                              color: Color(0xFFFFE000),
+                              fontSize: 48,
+                              fontWeight: FontWeight.w900)),
+                      Text('${_target.romaji} • ${_target.bnPronunciation}',
+                          style: TextStyle(
+                              color: Colors.white.withValues(alpha: 0.82),
+                              fontWeight: FontWeight.w700)),
+                      const SizedBox(height: 10),
+                      Row(
+                        mainAxisAlignment: MainAxisAlignment.center,
+                        children: [
+                          GestureDetector(
+                            onTap: _speak,
+                            child: Container(
+                              padding: const EdgeInsets.symmetric(
+                                  horizontal: 12, vertical: 6),
+                              decoration: BoxDecoration(
+                                color: const Color(0xFFFFE000)
+                                    .withValues(alpha: 0.18),
+                                borderRadius: BorderRadius.circular(99),
+                                border: Border.all(
+                                    color: const Color(0xFFFFE000)
+                                        .withValues(alpha: 0.6)),
+                              ),
+                              child: const Row(
+                                mainAxisSize: MainAxisSize.min,
+                                children: [
+                                  Icon(Icons.volume_up_rounded,
+                                      color: Color(0xFFFFE000), size: 16),
+                                  SizedBox(width: 4),
+                                  Text('শুনি',
+                                      style: TextStyle(
+                                          color: Color(0xFFFFE000),
+                                          fontWeight: FontWeight.w900,
+                                          fontSize: 12)),
+                                ],
+                              ),
+                            ),
+                          ),
+                          const SizedBox(width: 8),
+                          GestureDetector(
+                            onTap: () async {
+                              setState(() => _slowMode = !_slowMode);
+                              await _speak();
+                            },
+                            child: Container(
+                              padding: const EdgeInsets.symmetric(
+                                  horizontal: 12, vertical: 6),
+                              decoration: BoxDecoration(
+                                color: _slowMode
+                                    ? const Color(0xFFFFE000)
+                                    : Colors.white.withValues(alpha: 0.10),
+                                borderRadius: BorderRadius.circular(99),
+                                border: Border.all(
+                                    color: Colors.white.withValues(alpha: 0.2)),
+                              ),
+                              child: Row(
+                                mainAxisSize: MainAxisSize.min,
+                                children: [
+                                  Icon(Icons.pets_rounded,
+                                      color: _slowMode
+                                          ? const Color(0xFF1E293B)
+                                          : Colors.white,
+                                      size: 16),
+                                  const SizedBox(width: 4),
+                                  Text('ধীরে',
+                                      style: TextStyle(
+                                          color: _slowMode
+                                              ? const Color(0xFF1E293B)
+                                              : Colors.white,
+                                          fontWeight: FontWeight.w900,
+                                          fontSize: 12)),
+                                ],
+                              ),
+                            ),
+                          ),
+                        ],
+                      ),
+                      const SizedBox(height: 14),
+                      Container(
+                        width: double.infinity,
+                        padding: const EdgeInsets.all(14),
+                        decoration: BoxDecoration(
+                          color: _lastCorrect == null
+                              ? Colors.white.withValues(alpha: 0.07)
+                              : (_lastCorrect!
+                                  ? const Color(0xFF10B981).withValues(alpha: 0.16)
+                                  : const Color(0xFFEF4444).withValues(alpha: 0.16)),
+                          borderRadius: BorderRadius.circular(14),
+                          border: Border.all(
+                            color: _lastCorrect == null
+                                ? Colors.white.withValues(alpha: 0.14)
+                                : (_lastCorrect!
+                                    ? const Color(0xFF10B981)
+                                    : const Color(0xFFEF4444)),
+                            width: _lastCorrect == null ? 1 : 2,
+                          ),
+                        ),
+                        child: Row(
+                          children: [
+                            if (_lastCorrect != null) ...[
+                              Icon(
+                                _lastCorrect!
+                                    ? Icons.check_circle_rounded
+                                    : Icons.cancel_rounded,
+                                color: _lastCorrect!
+                                    ? const Color(0xFF10B981)
+                                    : const Color(0xFFEF4444),
+                              ),
+                              const SizedBox(width: 10),
+                            ],
+                            Expanded(
+                              child: Text(
+                                _shownMeaning,
+                                textAlign: TextAlign.center,
+                                style: const TextStyle(
+                                    color: Colors.white,
+                                    fontWeight: FontWeight.w900,
+                                    fontSize: 24),
+                              ),
+                            ),
+                          ],
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+              ),
+              const SizedBox(height: 12),
+              Row(
+                children: [
+                  Expanded(
+                    child: ElevatedButton.icon(
+                      onPressed: () => _answer(true),
+                      style: ElevatedButton.styleFrom(
+                          backgroundColor: const Color(0xFF10B981),
+                          foregroundColor: Colors.white,
+                          padding: const EdgeInsets.symmetric(vertical: 14)),
+                      icon: const Icon(Icons.check_circle_rounded),
+                      label: const Text('ঠিক',
+                          style: TextStyle(
+                              fontWeight: FontWeight.w900, fontSize: 18)),
+                    ),
+                  ),
+                  const SizedBox(width: 10),
+                  Expanded(
+                    child: ElevatedButton.icon(
+                      onPressed: () => _answer(false),
+                      style: ElevatedButton.styleFrom(
+                          backgroundColor: const Color(0xFFEF4444),
+                          foregroundColor: Colors.white,
+                          padding: const EdgeInsets.symmetric(vertical: 14)),
+                      icon: const Icon(Icons.cancel_rounded),
+                      label: const Text('ভুল',
+                          style: TextStyle(
+                              fontWeight: FontWeight.w900, fontSize: 18)),
+                    ),
+                  ),
+                ],
+              ),
+            ],
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+// ═════════════════════════════════════════════════════════════════════
+// শুনে বলো — Listening MCQ: audio plays Japanese, pick Bengali meaning
+// ═════════════════════════════════════════════════════════════════════
+
+class _HiListenGame extends StatefulWidget {
+  const _HiListenGame({super.key});
+
+  @override
+  State<_HiListenGame> createState() => _HiListenGameState();
+}
+
+class _HiListenGameState extends State<_HiListenGame>
+    with TickerProviderStateMixin {
+  static const _teal = Color(0xFF14B8A6);
+  static const _totalRounds = 8;
+  static const _sessionXpBonus = 50;
+
+  final _rng = math.Random();
+  final _tts = FlutterTts();
+  late final Future<void> _ttsReady;
+  late ConfettiController _confetti;
+  late AnimationController _shakeCtrl;
+
+  late _TimeGreeting _target;
+  late List<_TimeGreeting> _options;
+  int _roundIdx = 0;
+  int? _pickedId;
+  bool _locked = false;
+  bool _slowMode = false;
+  bool _showCorrectBanner = false;
+
+  late List<int> _deck;
+  int? _lastTargetId;
+
+  final Stopwatch _sessionTimer = Stopwatch();
+  int _correct = 0;
+  int _totalAttempts = 0;
+  int _xp = 0;
+  int _streak = 0;
+  int _bestStreak = 0;
+  final Map<int, int> _missed = {};
+
+  @override
+  void initState() {
+    super.initState();
+    _confetti = ConfettiController(duration: const Duration(milliseconds: 650));
+    _shakeCtrl =
+        AnimationController(vsync: this, duration: const Duration(milliseconds: 420));
+    _ttsReady = _initTts();
+    _newSession();
+  }
+
+  Future<void> _initTts() async {
+    await _tts.awaitSpeakCompletion(true);
+    await _tts.setLanguage('ja-JP');
+    await _tts.setSpeechRate(0.46);
+    await _tts.setPitch(1.05);
+    await _tts.setVolume(1.0);
+  }
+
+  Future<void> _applyRate() async {
+    await _ttsReady;
+    await _tts.setSpeechRate(_slowMode ? 0.30 : 0.46);
+  }
+
+  Future<void> _speak() async {
+    await _ttsReady;
+    await _tts.stop();
+    await _tts.speak(_target.jp);
+  }
+
+  void _newSession() {
+    _roundIdx = 0;
+    _correct = 0;
+    _totalAttempts = 0;
+    _xp = 0;
+    _streak = 0;
+    _bestStreak = 0;
+    _missed.clear();
+    _deck = [];
+    _lastTargetId = null;
+    _sessionTimer
+      ..reset()
+      ..start();
+    _buildRound();
+    WidgetsBinding.instance.addPostFrameCallback((_) => _speak());
+  }
+
+  int _drawTargetId() {
+    if (_deck.isEmpty) {
+      _deck = _timeGreetings.map((g) => g.id).toList()..shuffle(_rng);
+      // avoid back-to-back duplicate when refilling
+      if (_lastTargetId != null && _deck.length > 1 && _deck.first == _lastTargetId) {
+        _deck.add(_deck.removeAt(0));
+      }
+    }
+    final id = _deck.removeAt(0);
+    _lastTargetId = id;
+    return id;
+  }
+
+  void _buildRound() {
+    final id = _drawTargetId();
+    _target = _timeGreetings.firstWhere((g) => g.id == id);
+    final pool = _timeGreetings.where((g) => g.id != _target.id).toList()..shuffle(_rng);
+    setState(() {
+      _options = [_target, ...pool.take(3)]..shuffle(_rng);
+      _locked = false;
+      _pickedId = null;
+      _showCorrectBanner = false;
+    });
+  }
+
+  String _fmtDur(Duration d) {
+    final m = d.inMinutes.remainder(60).toString().padLeft(2, '0');
+    final s = d.inSeconds.remainder(60).toString().padLeft(2, '0');
+    return '$m:$s';
+  }
+
+  void _pick(_TimeGreeting o) {
+    if (_locked) return;
+    _totalAttempts += 1;
+    final ok = o.id == _target.id;
+    setState(() {
+      _locked = true;
+      _pickedId = o.id;
+    });
+    if (ok) {
+      HapticFeedback.mediumImpact();
+      setState(() {
+        _correct += 1;
+        _streak += 1;
+        if (_streak > _bestStreak) _bestStreak = _streak;
+        _xp += 10;
+        _showCorrectBanner = true;
+      });
+      _confetti.play();
+      Future.delayed(const Duration(milliseconds: 1200), () {
+        if (!mounted) return;
+        if (_roundIdx >= _totalRounds - 1) {
+          _sessionTimer.stop();
+          _xp += _sessionXpBonus;
+          _showEnd();
+        } else {
+          _roundIdx += 1;
+          _buildRound();
+          _speak();
+        }
+      });
+    } else {
+      HapticFeedback.heavyImpact();
+      setState(() {
+        _streak = 0;
+        _missed[_target.id] = (_missed[_target.id] ?? 0) + 1;
+      });
+      _shakeCtrl.forward(from: 0);
+      Future.delayed(const Duration(milliseconds: 700), () {
+        if (!mounted) return;
+        setState(() {
+          _pickedId = null;
+          _locked = false;
+        });
+      });
+    }
+  }
+
+  void _showEnd() {
+    final acc = _totalAttempts == 0 ? 0 : ((_correct * 100) / _totalAttempts).round();
+    showModalBottomSheet<void>(
+      context: context,
+      backgroundColor: Colors.transparent,
+      isScrollControlled: true,
+      builder: (_) => _HiAwesomeResultSheet(
+        title: 'শুনে বলো — সেশন শেষ',
+        scoreLabel: 'মোট XP: $_xp',
+        stats: [
+          'সঠিক: $_correct/$_totalRounds',
+          'নির্ভুলতা: $acc%',
+          'সেরা স্ট্রিক: $_bestStreak',
+          'সময়: ${_fmtDur(_sessionTimer.elapsed)}',
+        ],
+        missed: _missed.entries.map((e) {
+          final g = _timeGreetings.firstWhere((x) => x.id == e.key);
+          return '${g.bnPron} — ${g.bnMeaning}  ×${e.value}';
+        }).toList(),
+        onPlayAgain: () {
+          Navigator.of(context, rootNavigator: true).maybePop();
+          _newSession();
+        },
+      ),
+    );
+  }
+
+  @override
+  void dispose() {
+    _confetti.dispose();
+    _shakeCtrl.dispose();
+    _tts.stop();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final progress = (_roundIdx + 1) / _totalRounds;
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(16, 0, 16, 16),
+      child: Stack(
+        clipBehavior: Clip.none,
+        children: [
+          Align(
+            alignment: Alignment.topCenter,
+            child: IgnorePointer(
+              child: SizedBox(
+                height: 140,
+                width: double.infinity,
+                child: ConfettiWidget(
+                  confettiController: _confetti,
+                  blastDirectionality: BlastDirectionality.explosive,
+                  maxBlastForce: 16,
+                  minBlastForce: 6,
+                  emissionFrequency: 0.08,
+                  numberOfParticles: 14,
+                  gravity: 0.22,
+                  shouldLoop: false,
+                  colors: const [
+                    Color(0xFFFFE000),
+                    Color(0xFF10B981),
+                    _teal,
+                    Color(0xFF3B82F6),
+                  ],
+                ),
+              ),
+            ),
+          ),
+          Column(
+            children: [
+              _HiHeaderPanel(
+                color: _teal,
+                title: 'শুনে বলো — অডিও শুনে অর্থ বাছুন',
+                progress: progress,
+                roundText: 'রাউন্ড ${_roundIdx + 1}/$_totalRounds',
+                xp: _xp,
+                streak: _streak,
+                timer: _fmtDur(_sessionTimer.elapsed),
+              ),
+              const SizedBox(height: 12),
+              AnimatedBuilder(
+                animation: _shakeCtrl,
+                builder: (context, child) {
+                  final t = _shakeCtrl.value;
+                  final dx = math.sin(t * math.pi * 6) * 10 * (1 - t);
+                  return Transform.translate(offset: Offset(dx, 0), child: child);
+                },
+                child: Container(
+                  width: double.infinity,
+                  padding: const EdgeInsets.all(18),
+                  decoration: BoxDecoration(
+                    color: const Color(0xFF1E293B),
+                    borderRadius: BorderRadius.circular(20),
+                    border: Border.all(color: _teal.withValues(alpha: 0.55), width: 2),
+                    boxShadow: [
+                      BoxShadow(
+                        color: _teal.withValues(alpha: 0.18),
+                        blurRadius: 22,
+                        offset: const Offset(0, 8),
+                      ),
+                    ],
+                  ),
+                  child: Column(
+                    children: [
+                      Container(
+                        padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 6),
+                        decoration: BoxDecoration(
+                          color: _teal.withValues(alpha: 0.15),
+                          borderRadius: BorderRadius.circular(99),
+                        ),
+                        child: const Text(
+                          'অডিও শুনুন',
+                          style: TextStyle(
+                            color: _teal,
+                            fontSize: 12,
+                            fontWeight: FontWeight.w900,
+                            letterSpacing: 1.2,
+                          ),
+                        ),
+                      ),
+                      const SizedBox(height: 14),
+                      Text(
+                        _target.bnPron,
+                        textAlign: TextAlign.center,
+                        style: const TextStyle(
+                          color: Color(0xFFFFE000),
+                          fontSize: 26,
+                          fontWeight: FontWeight.w900,
+                        ),
+                      ),
+                      const SizedBox(height: 14),
+                      Row(
+                        children: [
+                          Expanded(
+                            child: ElevatedButton.icon(
+                              onPressed: _locked ? null : _speak,
+                              style: ElevatedButton.styleFrom(
+                                backgroundColor: _teal,
+                                foregroundColor: Colors.white,
+                                padding: const EdgeInsets.symmetric(vertical: 12),
+                                shape: RoundedRectangleBorder(
+                                    borderRadius: BorderRadius.circular(12)),
+                              ),
+                              icon: const Icon(Icons.volume_up_rounded),
+                              label: const Text('আবার শুনুন',
+                                  style: TextStyle(fontWeight: FontWeight.w900)),
+                            ),
+                          ),
+                          const SizedBox(width: 10),
+                          Expanded(
+                            child: OutlinedButton.icon(
+                              onPressed: _locked
+                                  ? null
+                                  : () async {
+                                      setState(() => _slowMode = !_slowMode);
+                                      await _applyRate();
+                                      await _speak();
+                                    },
+                              style: OutlinedButton.styleFrom(
+                                foregroundColor: _slowMode ? _teal : Colors.white,
+                                side: BorderSide(
+                                    color: _slowMode
+                                        ? _teal
+                                        : Colors.white.withValues(alpha: 0.28)),
+                                padding: const EdgeInsets.symmetric(vertical: 12),
+                                shape: RoundedRectangleBorder(
+                                    borderRadius: BorderRadius.circular(12)),
+                              ),
+                              icon: Icon(_slowMode
+                                  ? Icons.speed_rounded
+                                  : Icons.hourglass_bottom_rounded),
+                              label: Text(_slowMode ? 'স্বাভাবিক' : 'ধীর শোনা',
+                                  style: const TextStyle(fontWeight: FontWeight.w900)),
+                            ),
+                          ),
+                        ],
+                      ),
+                    ],
+                  ),
+                ),
+              ),
+              const SizedBox(height: 14),
+              const Text(
+                'এই অভিবাদনের বাংলা অর্থ কী?',
+                style: TextStyle(
+                  color: Colors.white,
+                  fontSize: 14,
+                  fontWeight: FontWeight.w900,
+                ),
+              ),
+              const SizedBox(height: 10),
+              Expanded(
+                child: Column(
+                  children: [
+                    for (int i = 0; i < _options.length; i++) ...[
+                      if (i != 0) const SizedBox(height: 10),
+                      _HiOptionTile(
+                        label: _options[i].bnMeaning,
+                        sublabel: _options[i].timeLabel,
+                        picked: _pickedId == _options[i].id,
+                        isCorrect: _options[i].id == _target.id,
+                        revealed: _pickedId != null,
+                        onTap: _locked ? null : () => _pick(_options[i]),
+                      ),
+                    ],
+                  ],
+                ),
+              ),
+            ],
+          ),
+          _HiCorrectBanner(
+            visible: _showCorrectBanner,
+            streak: _streak,
+            text: '${_target.bnPron} → ${_target.bnMeaning}',
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+// ═════════════════════════════════════════════════════════════════════
+// পড়ে বলো — Reading MCQ: scenario in Bengali → pick Bengali pronunciation
+// of the correct Japanese greeting (includes office trick questions)
+// ═════════════════════════════════════════════════════════════════════
+
+class _HiReadGame extends StatefulWidget {
+  const _HiReadGame({super.key});
+
+  @override
+  State<_HiReadGame> createState() => _HiReadGameState();
+}
+
+class _HiReadGameState extends State<_HiReadGame> with TickerProviderStateMixin {
+  static const _violet = Color(0xFF8B5CF6);
+  static const _totalRounds = 8;
+  static const _sessionXpBonus = 50;
+
+  final _rng = math.Random();
+  late ConfettiController _confetti;
+  late AnimationController _shakeCtrl;
+  late AnimationController _cardCtrl;
+
+  late _ReadScenario _scenario;
+  late _TimeGreeting _target;
+  late List<_TimeGreeting> _options;
+  int _roundIdx = 0;
+  int? _pickedId;
+  bool _locked = false;
+  bool _showCorrectBanner = false;
+  bool _showTrick = false;
+
+  final Stopwatch _sessionTimer = Stopwatch();
+  int _correct = 0;
+  int _totalAttempts = 0;
+  int _xp = 0;
+  int _streak = 0;
+  int _bestStreak = 0;
+  final Map<int, int> _missed = {};
+
+  @override
+  void initState() {
+    super.initState();
+    _confetti = ConfettiController(duration: const Duration(milliseconds: 650));
+    _shakeCtrl =
+        AnimationController(vsync: this, duration: const Duration(milliseconds: 420));
+    _cardCtrl =
+        AnimationController(vsync: this, duration: const Duration(milliseconds: 380));
+    _newSession();
+  }
+
+  late List<int> _scenarioDeck;
+  int? _lastScenarioIdx;
+
+  void _newSession() {
+    _roundIdx = 0;
+    _correct = 0;
+    _totalAttempts = 0;
+    _xp = 0;
+    _streak = 0;
+    _bestStreak = 0;
+    _missed.clear();
+    _scenarioDeck = [];
+    _lastScenarioIdx = null;
+    _sessionTimer
+      ..reset()
+      ..start();
+    _buildRound();
+  }
+
+  int _drawScenarioIdx() {
+    if (_scenarioDeck.isEmpty) {
+      _scenarioDeck = List<int>.generate(_readScenarios.length, (i) => i)
+        ..shuffle(_rng);
+      if (_lastScenarioIdx != null &&
+          _scenarioDeck.length > 1 &&
+          _scenarioDeck.first == _lastScenarioIdx) {
+        _scenarioDeck.add(_scenarioDeck.removeAt(0));
+      }
+    }
+    final idx = _scenarioDeck.removeAt(0);
+    _lastScenarioIdx = idx;
+    return idx;
+  }
+
+  void _buildRound() {
+    _scenario = _readScenarios[_drawScenarioIdx()];
+    _target = _timeGreetings.firstWhere((g) => g.id == _scenario.answerId);
+    final pool = _timeGreetings.where((g) => g.id != _target.id).toList()..shuffle(_rng);
+    setState(() {
+      _options = [_target, ...pool.take(3)]..shuffle(_rng);
+      _locked = false;
+      _pickedId = null;
+      _showCorrectBanner = false;
+      _showTrick = false;
+    });
+    _cardCtrl.forward(from: 0);
+  }
+
+  String _fmtDur(Duration d) {
+    final m = d.inMinutes.remainder(60).toString().padLeft(2, '0');
+    final s = d.inSeconds.remainder(60).toString().padLeft(2, '0');
+    return '$m:$s';
+  }
+
+  void _pick(_TimeGreeting o) {
+    if (_locked) return;
+    _totalAttempts += 1;
+    final ok = o.id == _target.id;
+    setState(() {
+      _locked = true;
+      _pickedId = o.id;
+    });
+    if (ok) {
+      HapticFeedback.mediumImpact();
+      setState(() {
+        _correct += 1;
+        _streak += 1;
+        if (_streak > _bestStreak) _bestStreak = _streak;
+        _xp += 10;
+        _showCorrectBanner = true;
+        _showTrick = _scenario.trick != null;
+      });
+      _confetti.play();
+      Future.delayed(const Duration(milliseconds: 1400), () {
+        if (!mounted) return;
+        if (_roundIdx >= _totalRounds - 1) {
+          _sessionTimer.stop();
+          _xp += _sessionXpBonus;
+          _showEnd();
+        } else {
+          _roundIdx += 1;
+          _buildRound();
+        }
+      });
+    } else {
+      HapticFeedback.heavyImpact();
+      setState(() {
+        _streak = 0;
+        _missed[_target.id] = (_missed[_target.id] ?? 0) + 1;
+        if (_scenario.trick != null) _showTrick = true;
+      });
+      _shakeCtrl.forward(from: 0);
+      Future.delayed(const Duration(milliseconds: 800), () {
+        if (!mounted) return;
+        setState(() {
+          _pickedId = null;
+          _locked = false;
+        });
+      });
+    }
+  }
+
+  void _showEnd() {
+    final acc = _totalAttempts == 0 ? 0 : ((_correct * 100) / _totalAttempts).round();
+    showModalBottomSheet<void>(
+      context: context,
+      backgroundColor: Colors.transparent,
+      isScrollControlled: true,
+      builder: (_) => _HiAwesomeResultSheet(
+        title: 'পড়ে বলো — সেশন শেষ',
+        scoreLabel: 'মোট XP: $_xp',
+        stats: [
+          'সঠিক: $_correct/$_totalRounds',
+          'নির্ভুলতা: $acc%',
+          'সেরা স্ট্রিক: $_bestStreak',
+          'সময়: ${_fmtDur(_sessionTimer.elapsed)}',
+        ],
+        missed: _missed.entries.map((e) {
+          final g = _timeGreetings.firstWhere((x) => x.id == e.key);
+          return '${g.bnPron} — ${g.bnMeaning}  ×${e.value}';
+        }).toList(),
+        onPlayAgain: () {
+          Navigator.of(context, rootNavigator: true).maybePop();
+          _newSession();
+        },
+      ),
+    );
+  }
+
+  @override
+  void dispose() {
+    _confetti.dispose();
+    _shakeCtrl.dispose();
+    _cardCtrl.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final progress = (_roundIdx + 1) / _totalRounds;
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(16, 0, 16, 16),
+      child: Stack(
+        clipBehavior: Clip.none,
+        children: [
+          Align(
+            alignment: Alignment.topCenter,
+            child: IgnorePointer(
+              child: SizedBox(
+                height: 140,
+                width: double.infinity,
+                child: ConfettiWidget(
+                  confettiController: _confetti,
+                  blastDirectionality: BlastDirectionality.explosive,
+                  maxBlastForce: 16,
+                  minBlastForce: 6,
+                  emissionFrequency: 0.08,
+                  numberOfParticles: 14,
+                  gravity: 0.22,
+                  shouldLoop: false,
+                  colors: const [
+                    Color(0xFFFFE000),
+                    Color(0xFF10B981),
+                    _violet,
+                    Color(0xFF3B82F6),
+                  ],
+                ),
+              ),
+            ),
+          ),
+          Column(
+            children: [
+              _HiHeaderPanel(
+                color: _violet,
+                title: 'পড়ে বলো — দৃশ্য পড়ে সঠিক উত্তর বাছুন',
+                progress: progress,
+                roundText: 'রাউন্ড ${_roundIdx + 1}/$_totalRounds',
+                xp: _xp,
+                streak: _streak,
+                timer: _fmtDur(_sessionTimer.elapsed),
+              ),
+              const SizedBox(height: 12),
+              AnimatedBuilder(
+                animation: _shakeCtrl,
+                builder: (context, child) {
+                  final t = _shakeCtrl.value;
+                  final dx = math.sin(t * math.pi * 6) * 10 * (1 - t);
+                  return Transform.translate(offset: Offset(dx, 0), child: child);
+                },
+                child: ScaleTransition(
+                  scale: Tween<double>(begin: 0.94, end: 1).animate(
+                      CurvedAnimation(parent: _cardCtrl, curve: Curves.easeOutBack)),
+                  child: Container(
+                    width: double.infinity,
+                    padding: const EdgeInsets.all(20),
+                    decoration: BoxDecoration(
+                      gradient: const LinearGradient(
+                        colors: [Color(0xFF1E293B), Color(0xFF111827)],
+                        begin: Alignment.topLeft,
+                        end: Alignment.bottomRight,
+                      ),
+                      borderRadius: BorderRadius.circular(20),
+                      border:
+                          Border.all(color: _violet.withValues(alpha: 0.55), width: 2),
+                      boxShadow: [
+                        BoxShadow(
+                          color: _violet.withValues(alpha: 0.22),
+                          blurRadius: 24,
+                          offset: const Offset(0, 8),
+                        ),
+                      ],
+                    ),
+                    child: Column(
+                      children: [
+                        Icon(_scenario.icon, color: _scenario.color, size: 52),
+                        const SizedBox(height: 10),
+                        Text(
+                          _scenario.scene,
+                          textAlign: TextAlign.center,
+                          style: const TextStyle(
+                            color: Colors.white,
+                            fontSize: 17,
+                            fontWeight: FontWeight.w900,
+                            height: 1.3,
+                          ),
+                        ),
+                        if (_scenario.trick != null) ...[
+                          const SizedBox(height: 8),
+                          Container(
+                            padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 4),
+                            decoration: BoxDecoration(
+                              color: Colors.orange.withValues(alpha: 0.18),
+                              borderRadius: BorderRadius.circular(99),
+                              border: Border.all(color: Colors.orange.withValues(alpha: 0.5)),
+                            ),
+                            child: const Text(
+                              '⚠️ ট্রিক প্রশ্ন',
+                              style: TextStyle(
+                                color: Colors.orange,
+                                fontWeight: FontWeight.w900,
+                                fontSize: 11,
+                              ),
+                            ),
+                          ),
+                        ],
+                        if (_showTrick && _scenario.trick != null) ...[
+                          const SizedBox(height: 10),
+                          Container(
+                            padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+                            decoration: BoxDecoration(
+                              color: const Color(0xFF10B981).withValues(alpha: 0.12),
+                              borderRadius: BorderRadius.circular(10),
+                              border: Border.all(color: const Color(0xFF10B981).withValues(alpha: 0.5)),
+                            ),
+                            child: Text(
+                              _scenario.trick!,
+                              textAlign: TextAlign.center,
+                              style: const TextStyle(
+                                color: Color(0xFF10B981),
+                                fontSize: 12,
+                                fontWeight: FontWeight.w700,
+                                height: 1.3,
+                              ),
+                            ),
+                          ),
+                        ],
+                      ],
+                    ),
+                  ),
+                ),
+              ),
+              const SizedBox(height: 14),
+              const Text(
+                'জাপানিতে সঠিক উত্তর কোনটি?',
+                style: TextStyle(
+                  color: Colors.white,
+                  fontSize: 14,
+                  fontWeight: FontWeight.w900,
+                ),
+              ),
+              const SizedBox(height: 10),
+              Expanded(
+                child: Column(
+                  children: [
+                    for (int i = 0; i < _options.length; i++) ...[
+                      if (i != 0) const SizedBox(height: 10),
+                      _HiOptionTile(
+                        label: _options[i].bnPron,
+                        sublabel: _options[i].bnMeaning,
+                        picked: _pickedId == _options[i].id,
+                        isCorrect: _options[i].id == _target.id,
+                        revealed: _pickedId != null,
+                        onTap: _locked ? null : () => _pick(_options[i]),
+                      ),
+                    ],
+                  ],
+                ),
+              ),
+            ],
+          ),
+          _HiCorrectBanner(
+            visible: _showCorrectBanner,
+            streak: _streak,
+            text: '${_target.bnMeaning} → ${_target.bnPron}',
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+// ═════════════════════════════════════════════════════════════════════
+// বলে দেখাও — Speaking: Bengali shown → user speaks Japanese
+// STT (ja-JP) evaluates with fuzzy matching
+// ═════════════════════════════════════════════════════════════════════
+
+class _HiSpeakGame extends StatefulWidget {
+  const _HiSpeakGame({super.key});
+
+  @override
+  State<_HiSpeakGame> createState() => _HiSpeakGameState();
+}
+
+class _HiSpeakGameState extends State<_HiSpeakGame> with TickerProviderStateMixin {
+  static const _rose = Color(0xFFE11D48);
+  static const _maxSeconds = 6;
+  static const _totalRounds = 6;
+  static const _sessionXpBonus = 50;
+
+  final _rng = math.Random();
+  final _tts = FlutterTts();
+  final _stt = SpeechToText();
+  bool _sttReady = false;
+  bool _ttsReady = false;
+  String? _locale;
+  String? _error;
+  bool _listening = false;
+  String _heard = '';
+  double _soundLevel = 0;
+  int _secondsLeft = 0;
+  Timer? _recordTimer;
+
+  late _TimeGreeting _target;
+  int _roundIdx = 0;
+  int? _lastScore;
+  bool _evaluated = false;
+  bool _showHint = false;
+
+  late ConfettiController _confetti;
+  late AnimationController _pulseCtrl;
+  late AnimationController _shakeCtrl;
+
+  final Stopwatch _sessionTimer = Stopwatch();
+  int _correct = 0;
+  int _attempts = 0;
+  int _xp = 0;
+  int _streak = 0;
+  int _bestStreak = 0;
+  final Map<int, int> _missed = {};
+
+  @override
+  void initState() {
+    super.initState();
+    _confetti = ConfettiController(duration: const Duration(milliseconds: 700));
+    _pulseCtrl = AnimationController(
+        vsync: this, duration: const Duration(milliseconds: 1100))
+      ..repeat(reverse: true);
+    _shakeCtrl =
+        AnimationController(vsync: this, duration: const Duration(milliseconds: 420));
+    _sessionTimer.start();
+    _initTts();
+    _initStt();
+    _newRound();
+  }
+
+  Future<void> _initTts() async {
+    try {
+      await _tts.setLanguage('ja-JP');
+      await _tts.setSpeechRate(0.45);
+      if (mounted) setState(() => _ttsReady = true);
+    } catch (_) {}
+  }
+
+  Future<void> _initStt() async {
+    try {
+      final ok = await _stt.initialize(
+        onError: (e) {
+          if (!mounted) return;
+          setState(() => _error = e.errorMsg);
+        },
+        onStatus: (_) {},
+      );
+      if (!mounted) return;
+      if (!ok) {
+        setState(() => _sttReady = false);
+        return;
+      }
+      final locales = await _stt.locales();
+      final ja = locales.where((l) => l.localeId.toLowerCase().startsWith('ja'));
+      setState(() {
+        _locale = ja.isNotEmpty
+            ? ja.first.localeId
+            : (locales.isNotEmpty ? locales.first.localeId : null);
+        _sttReady = true;
+      });
+    } catch (e) {
+      if (!mounted) return;
+      setState(() {
+        _sttReady = false;
+        _error = '$e';
+      });
+    }
+  }
+
+  List<int> _speakDeck = [];
+  int? _lastSpeakId;
+
+  int _drawSpeakId() {
+    if (_speakDeck.isEmpty) {
+      _speakDeck = _timeGreetings.map((g) => g.id).toList()..shuffle(_rng);
+      if (_lastSpeakId != null &&
+          _speakDeck.length > 1 &&
+          _speakDeck.first == _lastSpeakId) {
+        _speakDeck.add(_speakDeck.removeAt(0));
+      }
+    }
+    final id = _speakDeck.removeAt(0);
+    _lastSpeakId = id;
+    return id;
+  }
+
+  void _newRound() {
+    final id = _drawSpeakId();
+    setState(() {
+      _target = _timeGreetings.firstWhere((g) => g.id == id);
+      _heard = '';
+      _lastScore = null;
+      _evaluated = false;
+      _showHint = false;
+      _error = null;
+    });
+  }
+
+  // ─── Normalize Japanese STT output ─────────────────────────────────
+  static String _normJp(String s) {
+    var out = s.toLowerCase();
+    final buf = StringBuffer();
+    for (final r in out.runes) {
+      if (r >= 0xFF10 && r <= 0xFF19) {
+        buf.writeCharCode(r - 0xFF10 + 0x30);
+        continue;
+      }
+      if (r == 0x30FC) continue; // strip ー
+      // Small kana → big
+      const smallToBig = {
+        0x3041: 0x3042, 0x3043: 0x3044, 0x3045: 0x3046,
+        0x3047: 0x3048, 0x3049: 0x304A,
+        0x30A1: 0x30A2, 0x30A3: 0x30A4, 0x30A5: 0x30A6,
+        0x30A7: 0x30A8, 0x30A9: 0x30AA,
+      };
+      // Drop punctuation and common particles' filler
+      if (r == 0x3001 || r == 0x3002 || r == 0x002E || r == 0x002C ||
+          r == 0x0021 || r == 0x003F || r == 0x0020) {
+        continue;
+      }
+      buf.writeCharCode(smallToBig[r] ?? r);
+    }
+    return buf.toString();
+  }
+
+  // List of acceptable forms per greeting id.
+  static const Map<int, List<String>> _accepts = {
+    0: [
+      'おはようございます', 'おはようごさいます', 'おはよう', 'おはよ',
+      'ohayougozaimasu', 'ohayogozaimasu', 'ohayou', 'ohayo',
+    ],
+    1: [
+      'こんにちは', 'こんにちわ', 'konnichiwa', 'konnichiha',
+    ],
+    2: [
+      'こんばんは', 'こんばんわ', 'konbanwa', 'konbanha',
+    ],
+    3: [
+      'おやすみなさい', 'おやすみ', 'oyasuminasai', 'oyasumi',
+    ],
+  };
+
+  int _grade(String raw, _TimeGreeting target) {
+    final heard = _normJp(raw);
+    if (heard.isEmpty) return 0;
+    final accepts = (_accepts[target.id] ?? <String>[])
+        .map((e) => _normJp(e))
+        .toList();
+    for (final a in accepts) {
+      if (heard == a) return 100;
+    }
+    int best = 0;
+    for (final a in accepts) {
+      if (heard.contains(a) || a.contains(heard)) {
+        best = math.max(best, 92);
+      }
+      final sim = _similarity(heard, a);
+      best = math.max(best, (sim * 88).round());
+    }
+    return best.clamp(0, 100);
+  }
+
+  double _similarity(String a, String b) {
+    if (b.isEmpty) return 0;
+    int matches = 0;
+    final remaining = a.split('').toList();
+    for (final c in b.split('')) {
+      final idx = remaining.indexOf(c);
+      if (idx >= 0) {
+        matches++;
+        remaining.removeAt(idx);
+      }
+    }
+    return matches / b.length;
+  }
+
+  Future<void> _startListening() async {
+    if (_listening) return;
+    HapticFeedback.mediumImpact();
+    setState(() {
+      _heard = '';
+      _error = null;
+      _lastScore = null;
+      _evaluated = false;
+      _secondsLeft = _maxSeconds;
+      _soundLevel = 0;
+    });
+    try {
+      if (!_sttReady) await _initStt();
+      if (!_sttReady) {
+        throw Exception('Speech recognition এই ডিভাইসে কাজ করছে না।');
+      }
+      await _stt.listen(
+        localeId: _locale,
+        listenMode: ListenMode.confirmation,
+        partialResults: true,
+        cancelOnError: true,
+        listenFor: const Duration(seconds: _maxSeconds),
+        pauseFor: const Duration(seconds: 3),
+        onResult: (SpeechRecognitionResult r) {
+          if (!mounted) return;
+          setState(() => _heard = r.recognizedWords);
+        },
+        onSoundLevelChange: (level) {
+          if (!mounted) return;
+          setState(() => _soundLevel = level);
+        },
+      );
+      if (!mounted) return;
+      setState(() => _listening = true);
+      _recordTimer?.cancel();
+      _recordTimer = Timer.periodic(const Duration(seconds: 1), (_) async {
+        if (!mounted || !_listening) return;
+        if (_secondsLeft <= 1) {
+          await _stopAndCheck();
+          return;
+        }
+        setState(() => _secondsLeft -= 1);
+      });
+    } catch (e) {
+      if (!mounted) return;
+      _recordTimer?.cancel();
+      setState(() {
+        _listening = false;
+        _error = '$e';
+      });
+    }
+  }
+
+  Future<void> _stopAndCheck() async {
+    if (!_listening) return;
+    _recordTimer?.cancel();
+    HapticFeedback.selectionClick();
+    await _stt.stop();
+    if (!mounted) return;
+    setState(() {
+      _listening = false;
+      _secondsLeft = 0;
+      _soundLevel = 0;
+    });
+    final score = _grade(_heard, _target);
+    final ok = score >= 75;
+    _attempts += 1;
+    setState(() {
+      _lastScore = score;
+      _evaluated = true;
+      if (ok) {
+        _correct += 1;
+        _streak += 1;
+        if (_streak > _bestStreak) _bestStreak = _streak;
+        _xp += 10;
+      } else {
+        _streak = 0;
+        _missed[_target.id] = (_missed[_target.id] ?? 0) + 1;
+      }
+    });
+    if (ok) {
+      HapticFeedback.mediumImpact();
+      _confetti.play();
+    } else {
+      HapticFeedback.heavyImpact();
+      _shakeCtrl.forward(from: 0);
+    }
+  }
+
+  Future<void> _playNative() async {
+    if (!_ttsReady) return;
+    HapticFeedback.selectionClick();
+    await _tts.stop();
+    await _tts.speak(_target.jp);
+  }
+
+  Future<void> _next() async {
+    if (_roundIdx >= _totalRounds - 1) {
+      _sessionTimer.stop();
+      _xp += _sessionXpBonus;
+      _showEnd();
+      return;
+    }
+    _roundIdx += 1;
+    _newRound();
+  }
+
+  String _fmtDur(Duration d) {
+    final m = d.inMinutes.remainder(60).toString().padLeft(2, '0');
+    final s = d.inSeconds.remainder(60).toString().padLeft(2, '0');
+    return '$m:$s';
+  }
+
+  void _showEnd() {
+    final acc = _attempts == 0 ? 0 : ((_correct * 100) / _attempts).round();
+    showModalBottomSheet<void>(
+      context: context,
+      backgroundColor: Colors.transparent,
+      isScrollControlled: true,
+      builder: (_) => _HiAwesomeResultSheet(
+        title: 'বলে দেখাও — সেশন শেষ',
+        scoreLabel: 'মোট XP: $_xp',
+        stats: [
+          'সঠিক: $_correct/$_totalRounds',
+          'নির্ভুলতা: $acc%',
+          'সেরা স্ট্রিক: $_bestStreak',
+          'সময়: ${_fmtDur(_sessionTimer.elapsed)}',
+        ],
+        missed: _missed.entries.map((e) {
+          final g = _timeGreetings.firstWhere((x) => x.id == e.key);
+          return '${g.bnPron} — ${g.bnMeaning}  ×${e.value}';
+        }).toList(),
+        onPlayAgain: () {
+          Navigator.of(context, rootNavigator: true).maybePop();
+          setState(() {
+            _roundIdx = 0;
+            _correct = 0;
+            _attempts = 0;
+            _xp = 0;
+            _streak = 0;
+            _bestStreak = 0;
+            _missed.clear();
+            _speakDeck = [];
+            _lastSpeakId = null;
+            _sessionTimer
+              ..reset()
+              ..start();
+          });
+          _newRound();
+        },
+      ),
+    );
+  }
+
+  @override
+  void dispose() {
+    _recordTimer?.cancel();
+    _confetti.dispose();
+    _pulseCtrl.dispose();
+    _shakeCtrl.dispose();
+    _stt.stop();
+    _tts.stop();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final progress = (_roundIdx + 1) / _totalRounds;
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(16, 0, 16, 16),
+      child: Stack(
+        clipBehavior: Clip.none,
+        children: [
+          Align(
+            alignment: Alignment.topCenter,
+            child: IgnorePointer(
+              child: SizedBox(
+                height: 140,
+                width: double.infinity,
+                child: ConfettiWidget(
+                  confettiController: _confetti,
+                  blastDirectionality: BlastDirectionality.explosive,
+                  maxBlastForce: 16,
+                  minBlastForce: 6,
+                  emissionFrequency: 0.08,
+                  numberOfParticles: 14,
+                  gravity: 0.22,
+                  shouldLoop: false,
+                  colors: const [
+                    Color(0xFFFFE000),
+                    Color(0xFF10B981),
+                    _rose,
+                    Color(0xFF3B82F6),
+                  ],
+                ),
+              ),
+            ),
+          ),
+          Column(
+            children: [
+              _HiHeaderPanel(
+                color: _rose,
+                title: 'বলে দেখাও — বাংলা দেখে জাপানিতে বলুন',
+                progress: progress,
+                roundText: 'রাউন্ড ${_roundIdx + 1}/$_totalRounds',
+                xp: _xp,
+                streak: _streak,
+                timer: _fmtDur(_sessionTimer.elapsed),
+              ),
+              const SizedBox(height: 12),
+              AnimatedBuilder(
+                animation: _shakeCtrl,
+                builder: (context, child) {
+                  final t = _shakeCtrl.value;
+                  final dx = math.sin(t * math.pi * 6) * 10 * (1 - t);
+                  return Transform.translate(offset: Offset(dx, 0), child: child);
+                },
+                child: Container(
+                  width: double.infinity,
+                  padding: const EdgeInsets.all(18),
+                  decoration: BoxDecoration(
+                    color: const Color(0xFF1E293B),
+                    borderRadius: BorderRadius.circular(20),
+                    border: Border.all(color: _rose.withValues(alpha: 0.55), width: 2),
+                    boxShadow: [
+                      BoxShadow(
+                        color: _rose.withValues(alpha: 0.20),
+                        blurRadius: 22,
+                        offset: const Offset(0, 8),
+                      ),
+                    ],
+                  ),
+                  child: Column(
+                    children: [
+                      Icon(_target.icon, color: _target.color, size: 44),
+                      const SizedBox(height: 8),
+                      Text(
+                        _target.bnMeaning,
+                        style: const TextStyle(
+                          color: Colors.white,
+                          fontSize: 28,
+                          fontWeight: FontWeight.w900,
+                        ),
+                      ),
+                      const SizedBox(height: 4),
+                      Text(
+                        'জাপানিতে বলুন',
+                        style: TextStyle(
+                          color: Colors.white.withValues(alpha: 0.65),
+                          fontSize: 12,
+                          fontWeight: FontWeight.w700,
+                        ),
+                      ),
+                      if (_showHint || _evaluated) ...[
+                        const SizedBox(height: 10),
+                        Container(
+                          padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
+                          decoration: BoxDecoration(
+                            color: _rose.withValues(alpha: 0.15),
+                            borderRadius: BorderRadius.circular(99),
+                          ),
+                          child: Text(
+                            _target.bnPron,
+                            style: const TextStyle(
+                              color: Color(0xFFFFE000),
+                              fontSize: 18,
+                              fontWeight: FontWeight.w900,
+                            ),
+                          ),
+                        ),
+                        const SizedBox(height: 4),
+                        Text(
+                          _target.jp,
+                          style: TextStyle(
+                            color: Colors.white.withValues(alpha: 0.78),
+                            fontSize: 14,
+                            fontWeight: FontWeight.w700,
+                          ),
+                        ),
+                      ],
+                    ],
+                  ),
+                ),
+              ),
+              const SizedBox(height: 14),
+              GestureDetector(
+                onTap: _listening ? _stopAndCheck : _startListening,
+                child: AnimatedBuilder(
+                  animation: _pulseCtrl,
+                  builder: (context, _) {
+                    final scale = _listening
+                        ? 1 + (_pulseCtrl.value * 0.08) + (_soundLevel.clamp(0, 10) / 60)
+                        : 1.0;
+                    return Transform.scale(
+                      scale: scale,
+                      child: Container(
+                        width: 76,
+                        height: 76,
+                        decoration: BoxDecoration(
+                          shape: BoxShape.circle,
+                          gradient: LinearGradient(
+                            colors: _listening
+                                ? const [Color(0xFFEF4444), Color(0xFFB91C1C)]
+                                : const [_rose, Color(0xFFBE123C)],
+                          ),
+                          boxShadow: [
+                            BoxShadow(
+                              color: (_listening
+                                      ? const Color(0xFFEF4444)
+                                      : _rose)
+                                  .withValues(alpha: 0.5),
+                              blurRadius: 22,
+                              spreadRadius: 2,
+                            ),
+                          ],
+                        ),
+                        child: Icon(
+                          _listening ? Icons.stop_rounded : Icons.mic_rounded,
+                          color: Colors.white,
+                          size: 36,
+                        ),
+                      ),
+                    );
+                  },
+                ),
+              ),
+              const SizedBox(height: 8),
+              Text(
+                _listening
+                    ? 'শুনছি… $_secondsLeft s'
+                    : (_evaluated ? 'আবার বলতে মাইক চাপুন' : 'মাইক চাপুন'),
+                style: const TextStyle(
+                  color: Colors.white,
+                  fontWeight: FontWeight.w900,
+                  fontSize: 13,
+                ),
+              ),
+              if (_heard.isNotEmpty) ...[
+                const SizedBox(height: 8),
+                Container(
+                  width: double.infinity,
+                  padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+                  decoration: BoxDecoration(
+                    color: Colors.white.withValues(alpha: 0.06),
+                    borderRadius: BorderRadius.circular(10),
+                    border: Border.all(color: Colors.white.withValues(alpha: 0.12)),
+                  ),
+                  child: Text(
+                    'শোনা গেল: $_heard',
+                    textAlign: TextAlign.center,
+                    style: const TextStyle(
+                      color: Color(0xFFFFE000),
+                      fontWeight: FontWeight.w900,
+                      fontSize: 13,
+                    ),
+                  ),
+                ),
+              ],
+              if (_evaluated) ...[
+                const SizedBox(height: 10),
+                Container(
+                  padding: const EdgeInsets.all(12),
+                  decoration: BoxDecoration(
+                    color: ((_lastScore ?? 0) >= 75
+                            ? const Color(0xFF10B981)
+                            : const Color(0xFFEF4444))
+                        .withValues(alpha: 0.15),
+                    borderRadius: BorderRadius.circular(14),
+                    border: Border.all(
+                      color: ((_lastScore ?? 0) >= 75
+                              ? const Color(0xFF10B981)
+                              : const Color(0xFFEF4444))
+                          .withValues(alpha: 0.5),
+                    ),
+                  ),
+                  child: Row(
+                    children: [
+                      Icon(
+                        (_lastScore ?? 0) >= 75
+                            ? Icons.check_circle_rounded
+                            : Icons.cancel_rounded,
+                        color: (_lastScore ?? 0) >= 75
+                            ? const Color(0xFF10B981)
+                            : const Color(0xFFEF4444),
+                      ),
+                      const SizedBox(width: 8),
+                      Expanded(
+                        child: Text(
+                          (_lastScore ?? 0) >= 92
+                              ? 'চমৎকার উচ্চারণ! (${_lastScore ?? 0}%)'
+                              : (_lastScore ?? 0) >= 75
+                                  ? 'ভালো হয়েছে! (${_lastScore ?? 0}%)'
+                                  : 'আরেকবার চেষ্টা করুন (${_lastScore ?? 0}%)',
+                          style: TextStyle(
+                            color: (_lastScore ?? 0) >= 75
+                                ? const Color(0xFF10B981)
+                                : const Color(0xFFEF4444),
+                            fontWeight: FontWeight.w900,
+                            fontSize: 13,
+                          ),
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+              ],
+              if (_error != null) ...[
+                const SizedBox(height: 6),
+                Text(
+                  _error!,
+                  style: const TextStyle(
+                    color: Color(0xFFEF4444),
+                    fontSize: 11,
+                    fontWeight: FontWeight.w700,
+                  ),
+                  textAlign: TextAlign.center,
+                ),
+              ],
+              const Spacer(),
+              Row(
+                children: [
+                  Expanded(
+                    child: OutlinedButton.icon(
+                      onPressed: _ttsReady ? _playNative : null,
+                      style: OutlinedButton.styleFrom(
+                        foregroundColor: Colors.white,
+                        side: BorderSide(color: Colors.white.withValues(alpha: 0.4)),
+                        padding: const EdgeInsets.symmetric(vertical: 12),
+                        shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
+                      ),
+                      icon: const Icon(Icons.volume_up_rounded),
+                      label: const Text('সঠিক শুনুন',
+                          style: TextStyle(fontWeight: FontWeight.w900)),
+                    ),
+                  ),
+                  const SizedBox(width: 10),
+                  Expanded(
+                    child: OutlinedButton.icon(
+                      onPressed: () => setState(() => _showHint = !_showHint),
+                      style: OutlinedButton.styleFrom(
+                        foregroundColor: _showHint ? _rose : Colors.white,
+                        side: BorderSide(
+                            color: _showHint
+                                ? _rose
+                                : Colors.white.withValues(alpha: 0.4)),
+                        padding: const EdgeInsets.symmetric(vertical: 12),
+                        shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
+                      ),
+                      icon: Icon(_showHint ? Icons.visibility_off_rounded : Icons.lightbulb_rounded),
+                      label: Text(_showHint ? 'হিন্ট লুকান' : 'হিন্ট দেখুন',
+                          style: const TextStyle(fontWeight: FontWeight.w900)),
+                    ),
+                  ),
+                  const SizedBox(width: 10),
+                  Expanded(
+                    child: ElevatedButton.icon(
+                      onPressed: _evaluated ? _next : null,
+                      style: ElevatedButton.styleFrom(
+                        backgroundColor: _rose,
+                        foregroundColor: Colors.white,
+                        padding: const EdgeInsets.symmetric(vertical: 12),
+                        shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
+                      ),
+                      icon: const Icon(Icons.arrow_forward_rounded),
+                      label: const Text('পরবর্তী',
+                          style: TextStyle(fontWeight: FontWeight.w900)),
+                    ),
+                  ),
+                ],
+              ),
+            ],
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+// ═════════════════════════════════════════════════════════════════════
+// Shared widgets used by the three new games
+// ═════════════════════════════════════════════════════════════════════
+
+class _HiHeaderPanel extends StatelessWidget {
+  const _HiHeaderPanel({
+    required this.color,
+    required this.title,
+    required this.progress,
+    required this.roundText,
+    required this.xp,
+    required this.streak,
+    required this.timer,
+  });
+
+  final Color color;
+  final String title;
+  final double progress;
+  final String roundText;
+  final int xp;
+  final int streak;
+  final String timer;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.all(14),
+      decoration: BoxDecoration(
+        color: const Color(0xFF1E293B),
+        borderRadius: BorderRadius.circular(16),
+        border: Border.all(color: color.withValues(alpha: 0.45)),
+        boxShadow: [
+          BoxShadow(
+            color: color.withValues(alpha: 0.12),
+            blurRadius: 18,
+            offset: const Offset(0, 8),
+          ),
+        ],
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          Row(
+            children: [
+              Expanded(
+                child: Text(title,
+                    style: const TextStyle(
+                        color: Colors.white,
+                        fontWeight: FontWeight.w900,
+                        fontSize: 13)),
+              ),
+              Text(timer,
+                  style: TextStyle(
+                      color: Colors.white.withValues(alpha: 0.85),
+                      fontWeight: FontWeight.w900)),
+            ],
+          ),
+          const SizedBox(height: 10),
+          LinearProgressIndicator(
+            minHeight: 8,
+            borderRadius: BorderRadius.circular(99),
+            value: progress.clamp(0, 1),
+            backgroundColor: Colors.white.withValues(alpha: 0.12),
+            valueColor: AlwaysStoppedAnimation(color),
+          ),
+          const SizedBox(height: 8),
+          Row(
+            children: [
+              Text(roundText,
+                  style: TextStyle(
+                      color: Colors.white.withValues(alpha: 0.82),
+                      fontWeight: FontWeight.w800)),
+              const Spacer(),
+              Text('XP: $xp',
+                  style: const TextStyle(
+                      color: Color(0xFFFFE000),
+                      fontWeight: FontWeight.w900)),
+              const SizedBox(width: 10),
+              Text('স্ট্রিক: $streak',
+                  style: TextStyle(
+                      color: Colors.white.withValues(alpha: 0.82),
+                      fontWeight: FontWeight.w800)),
+            ],
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _HiOptionTile extends StatelessWidget {
+  const _HiOptionTile({
+    required this.label,
+    required this.sublabel,
+    required this.picked,
+    required this.isCorrect,
+    required this.revealed,
+    required this.onTap,
+  });
+
+  final String label;
+  final String sublabel;
+  final bool picked;
+  final bool isCorrect;
+  final bool revealed;
+  final VoidCallback? onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    Color border;
+    Color bg;
+    Color textColor = Colors.white;
+    if (!revealed) {
+      border = Colors.white.withValues(alpha: 0.18);
+      bg = Colors.white.withValues(alpha: 0.07);
+    } else if (isCorrect) {
+      border = const Color(0xFF10B981);
+      bg = const Color(0xFF10B981).withValues(alpha: 0.22);
+      textColor = const Color(0xFF10B981);
+    } else if (picked) {
+      border = const Color(0xFFEF4444);
+      bg = const Color(0xFFEF4444).withValues(alpha: 0.18);
+      textColor = const Color(0xFFEF4444);
+    } else {
+      border = Colors.white.withValues(alpha: 0.10);
+      bg = Colors.white.withValues(alpha: 0.04);
+    }
+    return Expanded(
+      child: Material(
+        color: Colors.transparent,
+        child: InkWell(
+          borderRadius: BorderRadius.circular(14),
+          onTap: onTap,
+          child: Ink(
+            decoration: BoxDecoration(
+              color: bg,
+              borderRadius: BorderRadius.circular(14),
+              border: Border.all(
+                color: border,
+                width: (picked || (isCorrect && revealed)) ? 2.4 : 1.2,
+              ),
+            ),
+            padding: const EdgeInsets.symmetric(horizontal: 12),
+            child: Row(
+              children: [
+                Expanded(
+                  child: Column(
+                    mainAxisAlignment: MainAxisAlignment.center,
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Text(
+                        label,
+                        style: TextStyle(
+                          color: textColor,
+                          fontSize: 17,
+                          fontWeight: FontWeight.w900,
+                        ),
+                      ),
+                      Text(
+                        sublabel,
+                        style: TextStyle(
+                          color: textColor.withValues(alpha: 0.65),
+                          fontSize: 11,
+                          fontWeight: FontWeight.w700,
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+                if (revealed && isCorrect)
+                  const Icon(Icons.check_circle_rounded,
+                      color: Color(0xFF10B981), size: 22),
+                if (revealed && picked && !isCorrect)
+                  const Icon(Icons.cancel_rounded,
+                      color: Color(0xFFEF4444), size: 22),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _HiCorrectBanner extends StatelessWidget {
+  const _HiCorrectBanner({
+    required this.visible,
+    required this.streak,
+    required this.text,
+  });
+
+  final bool visible;
+  final int streak;
+  final String text;
+
+  @override
+  Widget build(BuildContext context) {
+    return Positioned(
+      left: 0,
+      right: 0,
+      bottom: 0,
+      child: AnimatedSlide(
+        duration: const Duration(milliseconds: 360),
+        curve: Curves.easeOutCubic,
+        offset: visible ? Offset.zero : const Offset(0, 1.2),
+        child: AnimatedOpacity(
+          duration: const Duration(milliseconds: 220),
+          opacity: visible ? 1 : 0,
+          child: IgnorePointer(
+            ignoring: !visible,
+            child: Container(
+              margin: const EdgeInsets.only(bottom: 6),
+              padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 14),
+              decoration: BoxDecoration(
+                color: const Color(0xFF10B981),
+                borderRadius: BorderRadius.circular(16),
+                boxShadow: [
+                  BoxShadow(
+                    color: Colors.black.withValues(alpha: 0.35),
+                    blurRadius: 18,
+                    offset: const Offset(0, 8),
+                  ),
+                ],
+              ),
+              child: Column(
+                mainAxisSize: MainAxisSize.min,
+                crossAxisAlignment: CrossAxisAlignment.stretch,
+                children: [
+                  Row(
+                    children: [
+                      const Icon(Icons.thumb_up_alt_rounded,
+                          color: Colors.white, size: 26),
+                      const SizedBox(width: 10),
+                      const Text('সঠিক!',
+                          style: TextStyle(
+                              color: Colors.white,
+                              fontWeight: FontWeight.w900,
+                              fontSize: 22)),
+                      const Spacer(),
+                      Row(
+                        children: List.generate(
+                          5,
+                          (i) => Padding(
+                            padding: const EdgeInsets.only(left: 2),
+                            child: Icon(
+                              Icons.star_rounded,
+                              color: i < math.min(5, streak)
+                                  ? const Color(0xFFFFE000)
+                                  : Colors.white.withValues(alpha: 0.22),
+                              size: 22,
+                            ),
+                          ),
+                        ),
+                      ),
+                    ],
+                  ),
+                  const SizedBox(height: 6),
+                  Text(
+                    text,
+                    textAlign: TextAlign.center,
+                    style: const TextStyle(
+                      color: Colors.white,
+                      fontWeight: FontWeight.w800,
+                      fontSize: 15,
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _HiStatChip extends StatelessWidget {
+  const _HiStatChip({required this.label, required this.value});
+  final String label;
+  final String value;
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+      decoration: BoxDecoration(
+        color: Colors.white.withValues(alpha: 0.08),
+        borderRadius: BorderRadius.circular(8),
+        border: Border.all(color: Colors.white.withValues(alpha: 0.14)),
+      ),
+      child: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Text(label,
+              style: TextStyle(
+                  color: Colors.white.withValues(alpha: 0.7),
+                  fontSize: 10,
+                  fontWeight: FontWeight.w800)),
+          const SizedBox(width: 4),
+          Text(value,
+              style: const TextStyle(
+                  color: Color(0xFFFFE000),
+                  fontWeight: FontWeight.w900,
+                  fontSize: 12)),
+        ],
+      ),
+    );
+  }
+}
+
+class _HiFlipFace extends StatelessWidget {
+  const _HiFlipFace({super.key, required this.item, required this.turns});
+  final _Phrase item;
+  final double turns;
+
+  @override
+  Widget build(BuildContext context) {
+    return TweenAnimationBuilder<double>(
+      tween: Tween<double>(begin: 0, end: turns),
+      duration: const Duration(milliseconds: 420),
+      curve: Curves.easeInOutCubic,
+      builder: (context, value, _) {
+        final v = value % (2 * math.pi);
+        final showFront = v <= math.pi / 2 || v >= (3 * math.pi) / 2;
+        final angle = showFront ? v : v + math.pi;
+
+        final front = Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            Text(item.jp,
+                style: const TextStyle(
+                    color: Colors.white,
+                    fontSize: 52,
+                    fontWeight: FontWeight.w900)),
+            const SizedBox(height: 10),
+            Text(item.romaji,
+                style: TextStyle(
+                    color: Colors.white.withValues(alpha: 0.82),
+                    fontSize: 22,
+                    fontWeight: FontWeight.w700)),
+            const SizedBox(height: 4),
+            Text('উচ্চারণ: ${item.bnPronunciation}',
+                style: TextStyle(
+                    color: Colors.white.withValues(alpha: 0.86),
+                    fontWeight: FontWeight.w700)),
+          ],
+        );
+
+        final back = Text(
+          item.bn,
+          style: const TextStyle(
+              color: Color(0xFFFFE000),
+              fontSize: 46,
+              fontWeight: FontWeight.w900),
+          textAlign: TextAlign.center,
+        );
+
+        return Transform(
+          alignment: Alignment.center,
+          transform: Matrix4.identity()
+            ..setEntry(3, 2, 0.0012)
+            ..rotateY(angle),
+          child: showFront ? front : back,
+        );
+      },
+    );
+  }
+}
+
+BoxDecoration _deco({double radius = 16}) => BoxDecoration(
+      color: const Color(0xFF1E293B),
+      borderRadius: BorderRadius.circular(radius),
+      border: Border.all(color: Colors.white.withValues(alpha: 0.10)),
+    );
+
+
+void _showHiAwesomeResult({
+  required BuildContext context,
+  required String title,
+  required String scoreLabel,
+  required List<String> stats,
+  required List<MapEntry<String, int>> missed,
+  required VoidCallback onPlayAgain,
+}) {
+  final missedLines = <String>[];
+  for (final e in missed.take(6)) {
+    final p = _phrases.firstWhere((x) => x.jp == e.key);
+    missedLines.add('${p.jp} (${p.bnPronunciation}) → ${p.bn}  ×${e.value}');
+  }
+  showModalBottomSheet<void>(
+    context: context,
+    backgroundColor: Colors.transparent,
+    isScrollControlled: true,
+    builder: (_) => _HiAwesomeResultSheet(
+      title: title,
+      scoreLabel: scoreLabel,
+      stats: stats,
+      missed: missedLines,
+      onPlayAgain: onPlayAgain,
+    ),
+  );
+}
+
+class _HiAwesomeResultSheet extends StatelessWidget {
+  const _HiAwesomeResultSheet({
+    required this.title,
+    required this.scoreLabel,
+    required this.stats,
+    required this.missed,
+    required this.onPlayAgain,
+  });
+
+  final String title;
+  final String scoreLabel;
+  final List<String> stats;
+  final List<String> missed;
+  final VoidCallback onPlayAgain;
+
+  @override
+  Widget build(BuildContext context) {
+    return SafeArea(
+      child: Container(
+        margin: const EdgeInsets.fromLTRB(16, 0, 16, 16),
+        padding: const EdgeInsets.all(16),
+        decoration: BoxDecoration(
+          color: const Color(0xFF0B1326),
+          borderRadius: BorderRadius.circular(22),
+          border: Border.all(color: const Color(0xFFFFE000).withValues(alpha: 0.18)),
+          boxShadow: [
+            BoxShadow(
+              color: Colors.black.withValues(alpha: 0.35),
+              blurRadius: 22,
+              offset: const Offset(0, 12),
+            )
+          ],
+        ),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            Row(
+              children: [
+                const Icon(Icons.emoji_events_rounded, color: Color(0xFFFFE000)),
+                const SizedBox(width: 10),
+                Expanded(
+                  child: Text(title,
+                      style: const TextStyle(color: Colors.white, fontWeight: FontWeight.w900, fontSize: 16)),
+                ),
+                IconButton(
+                  onPressed: () => Navigator.pop(context),
+                  icon: const Icon(Icons.close_rounded, color: Colors.white),
+                ),
+              ],
+            ),
+            const SizedBox(height: 6),
+            Container(
+              padding: const EdgeInsets.all(14),
+              decoration: BoxDecoration(
+                color: Colors.white.withValues(alpha: 0.06),
+                borderRadius: BorderRadius.circular(16),
+                border: Border.all(color: Colors.white.withValues(alpha: 0.10)),
+              ),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(scoreLabel,
+                      style: const TextStyle(color: Color(0xFFFFE000), fontWeight: FontWeight.w900, fontSize: 22)),
+                  const SizedBox(height: 10),
+                  Wrap(
+                    spacing: 8,
+                    runSpacing: 8,
+                    children: [
+                      for (final s in stats)
+                        Container(
+                          padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 6),
+                          decoration: BoxDecoration(
+                            color: const Color(0xFF1E293B),
+                            borderRadius: BorderRadius.circular(999),
+                            border: Border.all(color: Colors.white.withValues(alpha: 0.10)),
+                          ),
+                          child: Text(s,
+                              style: TextStyle(
+                                  color: Colors.white.withValues(alpha: 0.92),
+                                  fontWeight: FontWeight.w800,
+                                  fontSize: 12)),
+                        ),
+                    ],
+                  ),
+                ],
+              ),
+            ),
+            if (missed.isNotEmpty) ...[
+              const SizedBox(height: 12),
+              const Text('যেগুলো মিস হয়েছে',
+                  style: TextStyle(color: Colors.white, fontWeight: FontWeight.w900)),
+              const SizedBox(height: 8),
+              for (final m in missed)
+                Padding(
+                  padding: const EdgeInsets.only(bottom: 8),
+                  child: Container(
+                    padding: const EdgeInsets.all(12),
+                    decoration: BoxDecoration(
+                      color: Colors.white.withValues(alpha: 0.05),
+                      borderRadius: BorderRadius.circular(14),
+                      border: Border.all(color: Colors.white.withValues(alpha: 0.10)),
+                    ),
+                    child: Text(m,
+                        style: TextStyle(color: Colors.white.withValues(alpha: 0.92), fontWeight: FontWeight.w800)),
+                  ),
+                ),
+            ],
+            const SizedBox(height: 10),
+            ElevatedButton.icon(
+              onPressed: () {
+                Navigator.pop(context);
+                onPlayAgain();
+              },
+              style: ElevatedButton.styleFrom(
+                backgroundColor: const Color(0xFFFFE000),
+                foregroundColor: const Color(0xFF1E293B),
+                padding: const EdgeInsets.symmetric(vertical: 12),
+                shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(14)),
+              ),
+              icon: const Icon(Icons.refresh_rounded),
+              label: const Text('আবার খেলি', style: TextStyle(fontWeight: FontWeight.w900)),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/screens/n5_weekdays_lesson_screen.dart
+++ b/lib/screens/n5_weekdays_lesson_screen.dart
@@ -1,0 +1,4476 @@
+// ignore_for_file: deprecated_member_use
+
+import 'dart:async';
+import 'dart:math' as math;
+
+import 'package:confetti/confetti.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_tts/flutter_tts.dart';
+import 'package:get/get.dart';
+import 'package:speech_to_text/speech_recognition_result.dart';
+import 'package:speech_to_text/speech_to_text.dart';
+
+class N5WeekdaysLessonScreen extends StatefulWidget {
+  const N5WeekdaysLessonScreen({super.key});
+
+  @override
+  State<N5WeekdaysLessonScreen> createState() => _N5WeekdaysLessonScreenState();
+}
+
+enum _WeekTab { flash, quiz, match, sequence, listen, read, speak, seqSpeak }
+
+class _N5WeekdaysLessonScreenState extends State<N5WeekdaysLessonScreen> {
+  static const _tabs = [
+    _WeekTab.listen,
+    _WeekTab.read,
+    _WeekTab.speak,
+    _WeekTab.seqSpeak,
+    _WeekTab.flash,
+    _WeekTab.quiz,
+    _WeekTab.match,
+    _WeekTab.sequence,
+  ];
+  int _tab = 0;
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      backgroundColor: const Color(0xFF0F172A),
+      body: SafeArea(
+        child: Column(
+          children: [
+            Padding(
+              padding: const EdgeInsets.fromLTRB(16, 10, 16, 12),
+              child: Row(
+                children: [
+                  GestureDetector(
+                    onTap: Get.back,
+                    child: Container(
+                      width: 40,
+                      height: 40,
+                      decoration: BoxDecoration(
+                        color: Colors.white.withValues(alpha: 0.18),
+                        shape: BoxShape.circle,
+                      ),
+                      child: const Icon(Icons.arrow_back_rounded, color: Colors.white),
+                    ),
+                  ),
+                  const SizedBox(width: 10),
+                  Expanded(
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        const Text('শুক্র-শনি বাকিটা জানি',
+                            style: TextStyle(
+                                color: Colors.white, fontWeight: FontWeight.w900, fontSize: 18)),
+                        Text('সপ্তাহের দিন: Japanese -> বাংলা',
+                            style: TextStyle(
+                                color: Colors.white.withValues(alpha: 0.75),
+                                fontWeight: FontWeight.w600,
+                                fontSize: 12)),
+                      ],
+                    ),
+                  ),
+                ],
+              ),
+            ),
+            Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 16),
+              child: _WeekTabPills(index: _tab, onChange: (i) => setState(() => _tab = i)),
+            ),
+            const SizedBox(height: 10),
+            Expanded(
+              child: AnimatedSwitcher(
+                duration: const Duration(milliseconds: 220),
+                child: switch (_tabs[_tab]) {
+                  _WeekTab.flash => const _WeekFlashGame(key: ValueKey('weekFlash')),
+                  _WeekTab.quiz => const _WeekQuizGame(key: ValueKey('weekQuiz')),
+                  _WeekTab.match => const _WeekMatchGame(key: ValueKey('weekMatch')),
+                  _WeekTab.sequence => const _WeekSequenceGame(key: ValueKey('weekSequence')),
+                  _WeekTab.listen => const _WeekListenGame(key: ValueKey('weekListen')),
+                  _WeekTab.read => const _WeekReadGame(key: ValueKey('weekRead')),
+                  _WeekTab.speak => const _WeekSpeakGame(key: ValueKey('weekSpeak')),
+                  _WeekTab.seqSpeak => const _WeekSeqSpeakGame(key: ValueKey('weekSeqSpeak')),
+                },
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _Weekday {
+  const _Weekday({required this.jp, required this.kana, required this.bnPronunciation, required this.bn});
+  final String jp;
+  final String kana;
+  final String bnPronunciation;
+  final String bn;
+}
+
+const _weekdays = <_Weekday>[
+  _Weekday(jp: '月曜日', kana: 'げつようび', bnPronunciation: 'গেৎসুওবি', bn: 'সোমবার'),
+  _Weekday(jp: '火曜日', kana: 'かようび', bnPronunciation: 'কায়োবি', bn: 'মঙ্গলবার'),
+  _Weekday(jp: '水曜日', kana: 'すいようび', bnPronunciation: 'সুইয়োবি', bn: 'বুধবার'),
+  _Weekday(jp: '木曜日', kana: 'もくようび', bnPronunciation: 'মোকুওবি', bn: 'বৃহস্পতিবার'),
+  _Weekday(jp: '金曜日', kana: 'きんようび', bnPronunciation: 'কিনয়োবি', bn: 'শুক্রবার'),
+  _Weekday(jp: '土曜日', kana: 'どようび', bnPronunciation: 'দোয়োবি', bn: 'শনিবার'),
+  _Weekday(jp: '日曜日', kana: 'にちようび', bnPronunciation: 'নিচিয়োবি', bn: 'রবিবার'),
+];
+
+// ─── Conceptual prompts used in পড়ে বলো (Heijitsu / Shumatsu rules) ──
+class _WeekConcept {
+  const _WeekConcept({
+    required this.prompt,
+    required this.options, // shown labels (Bengali)
+    required this.correctIdx,
+    required this.explanation,
+    this.icon = Icons.lightbulb_rounded,
+    this.color = const Color(0xFFFBBF24),
+  });
+  final String prompt;
+  final List<String> options;
+  final int correctIdx;
+  final String explanation;
+  final IconData icon;
+  final Color color;
+}
+
+const _weekConcepts = <_WeekConcept>[
+  _WeekConcept(
+    prompt: 'জাপানে সাপ্তাহিক কাজের দিনগুলোকে কী বলা হয়?',
+    options: ['হেইজিৎসু (平日)', 'শুমাৎসু (週末)', 'গেৎসুওবি', 'নিচিয়োবি'],
+    correctIdx: 0,
+    explanation: 'কাজের দিন = হেইজিৎসু (Heijitsu, 平日)। সাপ্তাহিক ছুটি = শুমাৎসু (Shumatsu, 週末)।',
+    icon: Icons.business_center_rounded,
+    color: Color(0xFF06B6D4),
+  ),
+  _WeekConcept(
+    prompt: 'হেইজিৎসু-র মধ্যে কোন দিনগুলো অন্তর্ভুক্ত?',
+    options: ['সোম–শুক্র', 'শনি–বুধ', 'শনি ও রবি', 'সোম–রবি (সব)'],
+    correctIdx: 0,
+    explanation: 'হেইজিৎসু = সোমবার থেকে শুক্রবার পর্যন্ত (গেৎসু → কিন)।',
+    icon: Icons.calendar_view_week_rounded,
+    color: Color(0xFF10B981),
+  ),
+  _WeekConcept(
+    prompt: 'শুমাৎসু (উইকএন্ড) কোন দিনগুলো?',
+    options: ['শনিবার ও রবিবার', 'শুক্রবার ও শনিবার', 'শুধু রবিবার', 'শুক্র, শনি, রবি'],
+    correctIdx: 0,
+    explanation: 'জাপানে শুমাৎসু = শনি (দোয়োবি) + রবি (নিচিয়োবি)। শুক্রবার এর মধ্যে নয়।',
+    icon: Icons.weekend_rounded,
+    color: Color(0xFF8B5CF6),
+  ),
+  _WeekConcept(
+    prompt: 'হেইজিৎসু কোন বার থেকে শুরু হয়?',
+    options: ['গেৎসুওবি (সোমবার)', 'নিচিয়োবি (রবিবার)', 'কায়োবি (মঙ্গলবার)', 'দোয়োবি (শনিবার)'],
+    correctIdx: 0,
+    explanation: 'কাজের সপ্তাহ গেৎসুওবি (সোমবার) থেকে শুরু হয়।',
+    icon: Icons.event_available_rounded,
+    color: Color(0xFFFBBF24),
+  ),
+  _WeekConcept(
+    prompt: 'নিচের কোন দিনটি শুমাৎসু-এর মধ্যে পড়ে?',
+    options: ['নিচিয়োবি', 'গেৎসুওবি', 'সুইয়োবি', 'মোকুওবি'],
+    correctIdx: 0,
+    explanation: 'নিচিয়োবি (রবিবার) শুমাৎসু-এর অংশ। বাকিগুলো হেইজিৎসু।',
+    icon: Icons.weekend_rounded,
+    color: Color(0xFFA855F7),
+  ),
+  _WeekConcept(
+    prompt: 'হেইজিৎসু-এর শেষ দিন কোনটি?',
+    options: ['কিনয়োবি (শুক্রবার)', 'দোয়োবি (শনিবার)', 'মোকুওবি (বৃহস্পতিবার)', 'নিচিয়োবি (রবিবার)'],
+    correctIdx: 0,
+    explanation: 'হেইজিৎসু-এর শেষ দিন = কিনয়োবি (শুক্রবার)।',
+    icon: Icons.event_busy_rounded,
+    color: Color(0xFFF97316),
+  ),
+];
+
+class _WeekTabPills extends StatelessWidget {
+  const _WeekTabPills({required this.index, required this.onChange});
+  final int index;
+  final ValueChanged<int> onChange;
+
+  @override
+  Widget build(BuildContext context) {
+    const labels = [
+      'শুনে বলো',
+      'পড়ে বলো',
+      'বলে দেখাও',
+      'ক্রম বলো',
+      'ফ্ল্যাশকার্ড',
+      'কুইজ রান',
+      'ডে ম্যাচ',
+      'নেক্সট ডে',
+    ];
+    return Container(
+      padding: const EdgeInsets.all(6),
+      decoration: BoxDecoration(
+        color: const Color(0xFF1E293B),
+        borderRadius: BorderRadius.circular(14),
+        border: Border.all(color: Colors.white.withValues(alpha: 0.08)),
+      ),
+      child: SingleChildScrollView(
+        scrollDirection: Axis.horizontal,
+        child: Row(
+          children: [
+            for (var i = 0; i < labels.length; i++) ...[
+              GestureDetector(
+                onTap: () => onChange(i),
+                child: AnimatedContainer(
+                  duration: const Duration(milliseconds: 180),
+                  padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 10),
+                  decoration: BoxDecoration(
+                    color: i == index ? const Color(0xFF3B82F6) : Colors.transparent,
+                    borderRadius: BorderRadius.circular(10),
+                  ),
+                  child: Text(labels[i],
+                      style: const TextStyle(
+                          color: Colors.white, fontWeight: FontWeight.w900, fontSize: 12)),
+                ),
+              ),
+              if (i != labels.length - 1) const SizedBox(width: 6),
+            ]
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _WeekFlashGame extends StatefulWidget {
+  const _WeekFlashGame({super.key});
+  @override
+  State<_WeekFlashGame> createState() => _WeekFlashGameState();
+}
+
+class _WeekFlashGameState extends State<_WeekFlashGame>
+    with TickerProviderStateMixin {
+  final _tts = FlutterTts();
+  late ConfettiController _confetti;
+  bool _ttsReady = false;
+  bool _slowMode = false;
+  int _i = 0;
+  bool _front = true;
+  double _flipTurns = 0;
+  int _xp = 0;
+  int _flips = 0;
+  final Set<int> _seen = {};
+  bool _doneShown = false;
+
+  _Weekday get _item => _weekdays[_i];
+
+  @override
+  void initState() {
+    super.initState();
+    _confetti = ConfettiController(duration: const Duration(milliseconds: 700));
+    _initTts();
+    _seen.add(0);
+  }
+
+  Future<void> _initTts() async {
+    try {
+      await _tts.setLanguage('ja-JP');
+      await _tts.setSpeechRate(_slowMode ? 0.32 : 0.50);
+      await _tts.setPitch(1.05);
+      if (!mounted) return;
+      setState(() => _ttsReady = true);
+    } catch (_) {}
+  }
+
+  Future<void> _speak() async {
+    if (!_ttsReady) return;
+    await _tts.stop();
+    await _tts.setSpeechRate(_slowMode ? 0.32 : 0.50);
+    await _tts.speak(_item.kana);
+  }
+
+  void _flip() {
+    HapticFeedback.selectionClick();
+    setState(() {
+      _front = !_front;
+      _flipTurns += math.pi;
+      _flips += 1;
+      _seen.add(_i);
+    });
+    if (!_front) {
+      // ignore: discarded_futures
+      _speak();
+    }
+  }
+
+  void _go(int delta) {
+    final next = (_i + delta).clamp(0, _weekdays.length - 1);
+    if (next == _i) return;
+    HapticFeedback.lightImpact();
+    setState(() {
+      _i = next;
+      _front = true;
+      _flipTurns = 0;
+      if (_seen.add(_i)) _xp += 10;
+    });
+    if (_seen.length == _weekdays.length && !_doneShown) {
+      _doneShown = true;
+      _confetti.play();
+      HapticFeedback.mediumImpact();
+    }
+    // ignore: discarded_futures
+    _speak();
+  }
+
+  @override
+  void dispose() {
+    _confetti.dispose();
+    _tts.stop();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final progress = _seen.length / _weekdays.length;
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(16, 0, 16, 16),
+      child: Stack(
+        clipBehavior: Clip.none,
+        children: [
+          Align(
+            alignment: Alignment.topCenter,
+            child: IgnorePointer(
+              child: SizedBox(
+                height: 130,
+                width: double.infinity,
+                child: ConfettiWidget(
+                  confettiController: _confetti,
+                  blastDirectionality: BlastDirectionality.explosive,
+                  maxBlastForce: 14,
+                  minBlastForce: 6,
+                  emissionFrequency: 0.08,
+                  numberOfParticles: 12,
+                  gravity: 0.22,
+                  shouldLoop: false,
+                  colors: const [
+                    Color(0xFFFFE000),
+                    Color(0xFF10B981),
+                    Color(0xFFFF8A34),
+                    Color(0xFF3B82F6),
+                  ],
+                ),
+              ),
+            ),
+          ),
+          Column(children: [
+            Container(
+              width: double.infinity,
+              padding: const EdgeInsets.all(14),
+              decoration: _card(),
+              child: Column(
+                children: [
+                  Row(
+                    children: [
+                      const Icon(Icons.calendar_month_rounded,
+                          color: Color(0xFFFFE000)),
+                      const SizedBox(width: 8),
+                      Text('দিন ${_i + 1}/${_weekdays.length}',
+                          style: const TextStyle(
+                              color: Colors.white, fontWeight: FontWeight.w900)),
+                      const SizedBox(width: 10),
+                      _WeekStatChip(label: 'XP', value: '$_xp'),
+                      const Spacer(),
+                      OutlinedButton(
+                        onPressed: _seen.isEmpty
+                            ? null
+                            : () => _showWeekAwesomeResult(
+                                  context: context,
+                                  title: 'ফ্ল্যাশকার্ড — রিভিউ',
+                                  scoreLabel: 'XP: $_xp',
+                                  stats: [
+                                    'দিন দেখা: ${_seen.length}/${_weekdays.length}',
+                                    'ফ্লিপ: $_flips',
+                                  ],
+                                  missed: const [],
+                                  onPlayAgain: () {
+                                    setState(() {
+                                      _xp = 0;
+                                      _flips = 0;
+                                      _seen.clear();
+                                      _seen.add(0);
+                                      _i = 0;
+                                      _front = true;
+                                      _flipTurns = 0;
+                                      _doneShown = false;
+                                    });
+                                  },
+                                ),
+                        style: OutlinedButton.styleFrom(
+                          foregroundColor: Colors.white,
+                          side: BorderSide(
+                              color: Colors.white.withValues(alpha: 0.22)),
+                        ),
+                        child: const Text('রিভিউ',
+                            style: TextStyle(fontWeight: FontWeight.w900)),
+                      ),
+                    ],
+                  ),
+                  const SizedBox(height: 8),
+                  LinearProgressIndicator(
+                    minHeight: 7,
+                    borderRadius: BorderRadius.circular(99),
+                    value: progress.clamp(0, 1),
+                    backgroundColor: Colors.white.withValues(alpha: 0.12),
+                    valueColor:
+                        const AlwaysStoppedAnimation(Color(0xFFFFE000)),
+                  ),
+                ],
+              ),
+            ),
+            const SizedBox(height: 10),
+            Expanded(
+              child: GestureDetector(
+                onTap: _flip,
+                child: Container(
+                  width: double.infinity,
+                  decoration: _card(radius: 22),
+                  child: Stack(
+                    children: [
+                      Center(
+                        child: AnimatedSwitcher(
+                          duration: const Duration(milliseconds: 280),
+                          switchInCurve: Curves.easeOutCubic,
+                          switchOutCurve: Curves.easeIn,
+                          transitionBuilder: (child, anim) {
+                            return FadeTransition(
+                              opacity: anim,
+                              child: ScaleTransition(
+                                scale: Tween<double>(begin: 0.94, end: 1.0)
+                                    .animate(CurvedAnimation(
+                                        parent: anim,
+                                        curve: Curves.easeOutCubic)),
+                                child: child,
+                              ),
+                            );
+                          },
+                          child: _WeekFlipFace(
+                            key: ValueKey(_i),
+                            item: _item,
+                            turns: _flipTurns,
+                          ),
+                        ),
+                      ),
+                      Positioned(
+                        top: 10,
+                        right: 10,
+                        child: Row(
+                          children: [
+                            GestureDetector(
+                              onTap: () async {
+                                setState(() => _slowMode = !_slowMode);
+                                await _speak();
+                              },
+                              child: Container(
+                                padding: const EdgeInsets.all(8),
+                                decoration: BoxDecoration(
+                                  color: _slowMode
+                                      ? const Color(0xFFFFE000)
+                                      : Colors.white.withValues(alpha: 0.12),
+                                  shape: BoxShape.circle,
+                                  border: Border.all(
+                                      color: Colors.white
+                                          .withValues(alpha: 0.2)),
+                                ),
+                                child: Icon(Icons.pets_rounded,
+                                    size: 18,
+                                    color: _slowMode
+                                        ? const Color(0xFF1E293B)
+                                        : Colors.white),
+                              ),
+                            ),
+                            const SizedBox(width: 8),
+                            GestureDetector(
+                              onTap: _speak,
+                              child: Container(
+                                padding: const EdgeInsets.all(8),
+                                decoration: BoxDecoration(
+                                  color: const Color(0xFFFFE000)
+                                      .withValues(alpha: 0.22),
+                                  shape: BoxShape.circle,
+                                  border: Border.all(
+                                      color: const Color(0xFFFFE000)
+                                          .withValues(alpha: 0.6)),
+                                ),
+                                child: const Icon(Icons.volume_up_rounded,
+                                    size: 18, color: Color(0xFFFFE000)),
+                              ),
+                            ),
+                          ],
+                        ),
+                      ),
+                      Positioned(
+                        bottom: 10,
+                        left: 0,
+                        right: 0,
+                        child: Center(
+                          child: Text(
+                            _front
+                                ? 'কার্ডে ট্যাপ করে অর্থ দেখো'
+                                : 'কার্ডে ট্যাপ করে আবার ঘোরাও',
+                            style: TextStyle(
+                                color: Colors.white.withValues(alpha: 0.55),
+                                fontWeight: FontWeight.w700,
+                                fontSize: 11),
+                          ),
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+              ),
+            ),
+            const SizedBox(height: 10),
+            Row(
+              children: [
+                Expanded(
+                  child: OutlinedButton.icon(
+                    onPressed: _i == 0 ? null : () => _go(-1),
+                    style: OutlinedButton.styleFrom(
+                        side: BorderSide(
+                            color: Colors.white.withValues(alpha: 0.2)),
+                        foregroundColor: Colors.white),
+                    icon: const Icon(Icons.navigate_before_rounded),
+                    label: const Text('আগেরটি',
+                        style: TextStyle(fontWeight: FontWeight.w900)),
+                  ),
+                ),
+                const SizedBox(width: 10),
+                Expanded(
+                  child: ElevatedButton.icon(
+                    onPressed:
+                        _i >= _weekdays.length - 1 ? null : () => _go(1),
+                    style: ElevatedButton.styleFrom(
+                        backgroundColor: const Color(0xFF3B82F6),
+                        foregroundColor: Colors.white),
+                    icon: const Icon(Icons.navigate_next_rounded),
+                    label: const Text('পরেরটি',
+                        style: TextStyle(fontWeight: FontWeight.w900)),
+                  ),
+                ),
+              ],
+            ),
+          ]),
+        ],
+      ),
+    );
+  }
+}
+
+class _WeekQuizGame extends StatefulWidget {
+  const _WeekQuizGame({super.key});
+  @override
+  State<_WeekQuizGame> createState() => _WeekQuizGameState();
+}
+
+class _WeekQuizGameState extends State<_WeekQuizGame>
+    with TickerProviderStateMixin {
+  final _rng = math.Random();
+  final _tts = FlutterTts();
+  late ConfettiController _confetti;
+  late AnimationController _shakeCtrl;
+  bool _ttsReady = false;
+  bool _slowMode = false;
+
+  late _Weekday _target;
+  late List<_Weekday> _options;
+  int _score = 0;
+  int _streak = 0;
+  int _bestStreak = 0;
+  int _attempts = 0;
+  int _correct = 0;
+  final Map<String, int> _missed = {};
+  bool _locked = false;
+  String? _picked;
+
+  @override
+  void initState() {
+    super.initState();
+    _confetti =
+        ConfettiController(duration: const Duration(milliseconds: 650));
+    _shakeCtrl = AnimationController(
+        vsync: this, duration: const Duration(milliseconds: 380));
+    _initTts();
+    _next(speak: false);
+  }
+
+  Future<void> _initTts() async {
+    try {
+      await _tts.setLanguage('ja-JP');
+      await _tts.setSpeechRate(_slowMode ? 0.32 : 0.50);
+      await _tts.setPitch(1.05);
+      if (!mounted) return;
+      setState(() => _ttsReady = true);
+      // ignore: discarded_futures
+      _speak();
+    } catch (_) {}
+  }
+
+  Future<void> _speak() async {
+    if (!_ttsReady) return;
+    await _tts.stop();
+    await _tts.setSpeechRate(_slowMode ? 0.32 : 0.50);
+    await _tts.speak(_target.kana);
+  }
+
+  void _next({bool speak = true}) {
+    final t = _weekdays[_rng.nextInt(_weekdays.length)];
+    final pool = _weekdays.where((e) => e.jp != t.jp).toList()..shuffle(_rng);
+    setState(() {
+      _target = t;
+      _options = [t, ...pool.take(3)]..shuffle(_rng);
+      _locked = false;
+      _picked = null;
+    });
+    if (speak && _ttsReady) {
+      // ignore: discarded_futures
+      _speak();
+    }
+  }
+
+  void _pick(_Weekday p) {
+    if (_locked) return;
+    final ok = p.jp == _target.jp;
+    setState(() {
+      _locked = true;
+      _picked = p.jp;
+      _attempts += 1;
+      if (ok) {
+        _streak += 1;
+        if (_streak > _bestStreak) _bestStreak = _streak;
+        _score += 10;
+        _correct += 1;
+      } else {
+        _streak = 0;
+        _missed[_target.jp] = (_missed[_target.jp] ?? 0) + 1;
+      }
+    });
+    if (ok) {
+      HapticFeedback.mediumImpact();
+      _confetti.play();
+    } else {
+      HapticFeedback.heavyImpact();
+      _shakeCtrl.forward(from: 0);
+    }
+    Future.delayed(const Duration(milliseconds: 620), () {
+      if (!mounted) return;
+      _next();
+    });
+  }
+
+  @override
+  void dispose() {
+    _confetti.dispose();
+    _shakeCtrl.dispose();
+    _tts.stop();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(16, 0, 16, 16),
+      child: Stack(
+        clipBehavior: Clip.none,
+        children: [
+          Align(
+            alignment: Alignment.topCenter,
+            child: IgnorePointer(
+              child: SizedBox(
+                height: 130,
+                width: double.infinity,
+                child: ConfettiWidget(
+                  confettiController: _confetti,
+                  blastDirectionality: BlastDirectionality.explosive,
+                  maxBlastForce: 14,
+                  minBlastForce: 6,
+                  emissionFrequency: 0.08,
+                  numberOfParticles: 12,
+                  gravity: 0.22,
+                  shouldLoop: false,
+                  colors: const [
+                    Color(0xFFFFE000),
+                    Color(0xFF10B981),
+                    Color(0xFFFF8A34),
+                    Color(0xFF3B82F6),
+                  ],
+                ),
+              ),
+            ),
+          ),
+          Column(children: [
+            Container(
+              width: double.infinity,
+              padding: const EdgeInsets.all(14),
+              decoration: _card(),
+              child: Row(
+                children: [
+                  const Icon(Icons.bolt_rounded, color: Color(0xFFFFE000)),
+                  const SizedBox(width: 8),
+                  Text('স্কোর: $_score',
+                      style: const TextStyle(
+                          color: Colors.white, fontWeight: FontWeight.w900)),
+                  const SizedBox(width: 10),
+                  _WeekStatChip(label: 'স্ট্রিক', value: '$_streak'),
+                  const SizedBox(width: 6),
+                  _WeekStatChip(label: 'সেরা', value: '$_bestStreak'),
+                  const Spacer(),
+                  OutlinedButton(
+                    onPressed: _attempts == 0
+                        ? null
+                        : () => _showWeekAwesomeResult(
+                              context: context,
+                              title: 'কুইজ রান — রিভিউ',
+                              scoreLabel: 'স্কোর: $_score',
+                              stats: [
+                                'চেষ্টা: $_attempts',
+                                'সঠিক: $_correct',
+                                'নির্ভুলতা: ${((_correct * 100) / _attempts).round()}%',
+                                'সেরা স্ট্রিক: $_bestStreak',
+                              ],
+                              missed: _missed.entries.toList()
+                                ..sort((a, b) => b.value.compareTo(a.value)),
+                              onPlayAgain: () {
+                                setState(() {
+                                  _score = 0;
+                                  _streak = 0;
+                                  _bestStreak = 0;
+                                  _attempts = 0;
+                                  _correct = 0;
+                                  _missed.clear();
+                                });
+                                _next();
+                              },
+                            ),
+                    style: OutlinedButton.styleFrom(
+                      foregroundColor: Colors.white,
+                      side: BorderSide(
+                          color: Colors.white.withValues(alpha: 0.22)),
+                    ),
+                    child: const Text('রিভিউ',
+                        style: TextStyle(fontWeight: FontWeight.w900)),
+                  ),
+                ],
+              ),
+            ),
+            const SizedBox(height: 10),
+            AnimatedBuilder(
+              animation: _shakeCtrl,
+              builder: (_, child) {
+                final wrong = _picked != null && _picked != _target.jp;
+                final dx = wrong
+                    ? math.sin(_shakeCtrl.value * math.pi * 6) * 8
+                    : 0.0;
+                return Transform.translate(
+                    offset: Offset(dx, 0), child: child);
+              },
+              child: Container(
+                width: double.infinity,
+                padding: const EdgeInsets.all(16),
+                decoration: _card(radius: 18),
+                child: Column(
+                  children: [
+                    const Text('এই জাপানি দিনটির বাংলা কোনটি?',
+                        textAlign: TextAlign.center,
+                        style: TextStyle(
+                            color: Colors.white, fontWeight: FontWeight.w900)),
+                    const SizedBox(height: 10),
+                    Text(_target.jp,
+                        style: const TextStyle(
+                            color: Color(0xFFFFE000),
+                            fontSize: 44,
+                            fontWeight: FontWeight.w900)),
+                    const SizedBox(height: 4),
+                    Text(_target.kana,
+                        style: TextStyle(
+                            color: Colors.white.withValues(alpha: 0.82),
+                            fontWeight: FontWeight.w700,
+                            fontSize: 20)),
+                    Text('উচ্চারণ: ${_target.bnPronunciation}',
+                        style: TextStyle(
+                            color: Colors.white.withValues(alpha: 0.85),
+                            fontWeight: FontWeight.w700)),
+                    const SizedBox(height: 10),
+                    Row(
+                      mainAxisAlignment: MainAxisAlignment.center,
+                      children: [
+                        GestureDetector(
+                          onTap: _speak,
+                          child: Container(
+                            padding: const EdgeInsets.symmetric(
+                                horizontal: 14, vertical: 8),
+                            decoration: BoxDecoration(
+                              color: const Color(0xFFFFE000)
+                                  .withValues(alpha: 0.18),
+                              borderRadius: BorderRadius.circular(99),
+                              border: Border.all(
+                                  color: const Color(0xFFFFE000)
+                                      .withValues(alpha: 0.6)),
+                            ),
+                            child: const Row(
+                              mainAxisSize: MainAxisSize.min,
+                              children: [
+                                Icon(Icons.volume_up_rounded,
+                                    color: Color(0xFFFFE000), size: 18),
+                                SizedBox(width: 6),
+                                Text('শুনি',
+                                    style: TextStyle(
+                                        color: Color(0xFFFFE000),
+                                        fontWeight: FontWeight.w900)),
+                              ],
+                            ),
+                          ),
+                        ),
+                        const SizedBox(width: 10),
+                        GestureDetector(
+                          onTap: () async {
+                            setState(() => _slowMode = !_slowMode);
+                            await _speak();
+                          },
+                          child: Container(
+                            padding: const EdgeInsets.symmetric(
+                                horizontal: 14, vertical: 8),
+                            decoration: BoxDecoration(
+                              color: _slowMode
+                                  ? const Color(0xFFFFE000)
+                                  : Colors.white.withValues(alpha: 0.10),
+                              borderRadius: BorderRadius.circular(99),
+                              border: Border.all(
+                                  color: Colors.white.withValues(alpha: 0.2)),
+                            ),
+                            child: Row(
+                              mainAxisSize: MainAxisSize.min,
+                              children: [
+                                Icon(Icons.pets_rounded,
+                                    color: _slowMode
+                                        ? const Color(0xFF1E293B)
+                                        : Colors.white,
+                                    size: 18),
+                                const SizedBox(width: 6),
+                                Text('ধীরে',
+                                    style: TextStyle(
+                                        color: _slowMode
+                                            ? const Color(0xFF1E293B)
+                                            : Colors.white,
+                                        fontWeight: FontWeight.w900)),
+                              ],
+                            ),
+                          ),
+                        ),
+                      ],
+                    ),
+                  ],
+                ),
+              ),
+            ),
+            const SizedBox(height: 10),
+            Expanded(
+              child: ListView.separated(
+                itemCount: _options.length,
+                separatorBuilder: (_, __) => const SizedBox(height: 10),
+                itemBuilder: (_, i) {
+                  final o = _options[i];
+                  final picked = _picked == o.jp;
+                  final correct = o.jp == _target.jp;
+                  final bg = _picked == null
+                      ? Colors.white.withValues(alpha: 0.06)
+                      : (correct
+                          ? const Color(0xFF10B981).withValues(alpha: 0.22)
+                          : (picked
+                              ? const Color(0xFFEF4444).withValues(alpha: 0.22)
+                              : Colors.white.withValues(alpha: 0.05)));
+                  final border = _picked == null
+                      ? Colors.white.withValues(alpha: 0.16)
+                      : (correct
+                          ? const Color(0xFF10B981)
+                          : (picked
+                              ? const Color(0xFFEF4444)
+                              : Colors.white.withValues(alpha: 0.16)));
+                  return GestureDetector(
+                    onTap: () => _pick(o),
+                    child: AnimatedScale(
+                      scale: picked && correct ? 1.03 : 1.0,
+                      duration: const Duration(milliseconds: 220),
+                      child: Container(
+                        padding: const EdgeInsets.all(14),
+                        decoration: BoxDecoration(
+                          color: bg,
+                          borderRadius: BorderRadius.circular(14),
+                          border: Border.all(
+                              color: border, width: _picked == null ? 1 : 2),
+                        ),
+                        child: Row(
+                          children: [
+                            if (picked || (correct && _picked != null))
+                              Padding(
+                                padding: const EdgeInsets.only(right: 8),
+                                child: Icon(
+                                  correct
+                                      ? Icons.check_circle_rounded
+                                      : Icons.cancel_rounded,
+                                  color: correct
+                                      ? const Color(0xFF10B981)
+                                      : const Color(0xFFEF4444),
+                                  size: 20,
+                                ),
+                              ),
+                            Expanded(
+                              child: Text(o.bn,
+                                  style: const TextStyle(
+                                      color: Colors.white,
+                                      fontWeight: FontWeight.w900,
+                                      fontSize: 18)),
+                            ),
+                          ],
+                        ),
+                      ),
+                    ),
+                  );
+                },
+              ),
+            ),
+          ]),
+        ],
+      ),
+    );
+  }
+}
+
+class _DayPair {
+  final String keyId;
+  final String label;
+  const _DayPair({required this.keyId, required this.label});
+}
+
+class _WeekMatchGame extends StatefulWidget {
+  const _WeekMatchGame({super.key});
+  @override
+  State<_WeekMatchGame> createState() => _WeekMatchGameState();
+}
+
+class _WeekMatchGameState extends State<_WeekMatchGame>
+    with TickerProviderStateMixin {
+  final _rng = math.Random();
+  final _tts = FlutterTts();
+  late ConfettiController _confetti;
+  late AnimationController _shakeCtrl;
+  bool _ttsReady = false;
+
+  late List<_DayPair> _jpColumn;
+  late List<_DayPair> _bnColumn;
+  int? _selectedJpIdx;
+  int? _selectedBnIdx;
+  final _matchedKeys = <String>{};
+  int _moves = 0;
+  int _wrongJp = -1;
+  int _wrongBn = -1;
+  int _wrongMoves = 0;
+  int _streak = 0;
+  int _bestStreak = 0;
+  int _xp = 0;
+  final Map<String, int> _missesByKey = {};
+  final Stopwatch _stopwatch = Stopwatch();
+  Timer? _ticker;
+
+  @override
+  void initState() {
+    super.initState();
+    _confetti = ConfettiController(duration: const Duration(milliseconds: 700));
+    _shakeCtrl = AnimationController(
+        vsync: this, duration: const Duration(milliseconds: 380));
+    _initTts();
+    _reset();
+  }
+
+  Future<void> _initTts() async {
+    try {
+      await _tts.setLanguage('ja-JP');
+      await _tts.setSpeechRate(0.50);
+      await _tts.setPitch(1.05);
+      if (!mounted) return;
+      setState(() => _ttsReady = true);
+    } catch (_) {}
+  }
+
+  Future<void> _speak(String key) async {
+    if (!_ttsReady) return;
+    final day = _weekdays.firstWhere((d) => d.jp == key);
+    await _tts.stop();
+    await _tts.speak(day.kana);
+  }
+
+  String _formatDuration(Duration d) {
+    final m = d.inMinutes.remainder(60).toString().padLeft(2, '0');
+    final s = d.inSeconds.remainder(60).toString().padLeft(2, '0');
+    return '$m:$s';
+  }
+
+  void _reset() {
+    final jp = <_DayPair>[];
+    final bn = <_DayPair>[];
+    for (final d in _weekdays) {
+      jp.add(_DayPair(keyId: d.jp, label: '${d.jp}\n(${d.bnPronunciation})'));
+      bn.add(_DayPair(keyId: d.jp, label: d.bn));
+    }
+    jp.shuffle(_rng);
+    bn.shuffle(_rng);
+    setState(() {
+      _jpColumn = jp;
+      _bnColumn = bn;
+      _selectedJpIdx = null;
+      _selectedBnIdx = null;
+      _matchedKeys.clear();
+      _missesByKey.clear();
+      _moves = 0;
+      _wrongJp = -1;
+      _wrongBn = -1;
+      _wrongMoves = 0;
+      _streak = 0;
+      _bestStreak = 0;
+      _xp = 0;
+    });
+    _stopwatch
+      ..reset()
+      ..start();
+    _ticker?.cancel();
+    _ticker = Timer.periodic(const Duration(seconds: 1), (_) {
+      if (mounted) setState(() {});
+    });
+  }
+
+  void _tapJp(int idx) {
+    final key = _jpColumn[idx].keyId;
+    if (_matchedKeys.contains(key)) return;
+    HapticFeedback.selectionClick();
+    // ignore: discarded_futures
+    _speak(key);
+    setState(() {
+      _wrongJp = -1;
+      _wrongBn = -1;
+      _selectedJpIdx = idx;
+    });
+    _tryMatch();
+  }
+
+  void _tapBn(int idx) {
+    final key = _bnColumn[idx].keyId;
+    if (_matchedKeys.contains(key)) return;
+    HapticFeedback.selectionClick();
+    setState(() {
+      _wrongJp = -1;
+      _wrongBn = -1;
+      _selectedBnIdx = idx;
+    });
+    _tryMatch();
+  }
+
+  void _tryMatch() {
+    if (_selectedJpIdx == null || _selectedBnIdx == null) return;
+    _moves += 1;
+    final jp = _jpColumn[_selectedJpIdx!];
+    final bn = _bnColumn[_selectedBnIdx!];
+    final ok = jp.keyId == bn.keyId;
+    if (ok) {
+      HapticFeedback.mediumImpact();
+      setState(() {
+        _matchedKeys.add(jp.keyId);
+        _selectedJpIdx = null;
+        _selectedBnIdx = null;
+        _streak += 1;
+        if (_streak > _bestStreak) _bestStreak = _streak;
+        _xp += 10;
+      });
+      _confetti.play();
+      if (_matchedKeys.length == _jpColumn.length) {
+        _stopwatch.stop();
+        _ticker?.cancel();
+        Future.delayed(const Duration(milliseconds: 600), () {
+          if (!mounted) return;
+          _showWeekAwesomeResult(
+            context: context,
+            title: 'ডে ম্যাচ — সব মিলেছে',
+            scoreLabel: 'XP: $_xp',
+            stats: [
+              'মুভ: $_moves',
+              'ভুল: $_wrongMoves',
+              'নির্ভুলতা: ${_moves == 0 ? 0 : (((_moves - _wrongMoves) * 100) / _moves).round()}%',
+              'সেরা স্ট্রিক: $_bestStreak',
+              'সময়: ${_formatDuration(_stopwatch.elapsed)}',
+            ],
+            missed: _missesByKey.entries.toList()
+              ..sort((a, b) => b.value.compareTo(a.value)),
+            onPlayAgain: _reset,
+          );
+        });
+      }
+      return;
+    }
+    HapticFeedback.heavyImpact();
+    _wrongMoves += 1;
+    _missesByKey[jp.keyId] = (_missesByKey[jp.keyId] ?? 0) + 1;
+    _missesByKey[bn.keyId] = (_missesByKey[bn.keyId] ?? 0) + 1;
+    final wrongJpIdx = _selectedJpIdx!;
+    final wrongBnIdx = _selectedBnIdx!;
+    setState(() {
+      _wrongJp = wrongJpIdx;
+      _wrongBn = wrongBnIdx;
+      _selectedJpIdx = null;
+      _selectedBnIdx = null;
+      _streak = 0;
+    });
+    _shakeCtrl.forward(from: 0);
+    Future.delayed(const Duration(milliseconds: 460), () {
+      if (!mounted) return;
+      setState(() {
+        if (_wrongJp == wrongJpIdx) _wrongJp = -1;
+        if (_wrongBn == wrongBnIdx) _wrongBn = -1;
+      });
+    });
+  }
+
+  @override
+  void dispose() {
+    _confetti.dispose();
+    _shakeCtrl.dispose();
+    _ticker?.cancel();
+    _tts.stop();
+    super.dispose();
+  }
+
+  Widget _buildCard(_DayPair c, int idx, bool isJp) {
+    final selected = isJp ? _selectedJpIdx == idx : _selectedBnIdx == idx;
+    final matched = _matchedKeys.contains(c.keyId);
+    final wrong = isJp ? _wrongJp == idx : _wrongBn == idx;
+    final border = matched
+        ? const Color(0xFF10B981)
+        : (wrong
+            ? const Color(0xFFEF4444)
+            : (selected
+                ? const Color(0xFFFFE000)
+                : Colors.white.withValues(alpha: 0.14)));
+    final bg = matched
+        ? const Color(0xFF10B981).withValues(alpha: 0.17)
+        : (wrong
+            ? const Color(0xFFEF4444).withValues(alpha: 0.14)
+            : (selected
+                ? const Color(0xFFFFE000).withValues(alpha: 0.13)
+                : Colors.white.withValues(alpha: 0.06)));
+    return AnimatedBuilder(
+      animation: _shakeCtrl,
+      builder: (_, child) {
+        final dx = wrong ? math.sin(_shakeCtrl.value * math.pi * 6) * 6 : 0.0;
+        return Transform.translate(offset: Offset(dx, 0), child: child);
+      },
+      child: GestureDetector(
+        onTap: () => isJp ? _tapJp(idx) : _tapBn(idx),
+        child: Container(
+          padding: const EdgeInsets.all(12),
+          decoration: BoxDecoration(
+            color: bg,
+            borderRadius: BorderRadius.circular(14),
+            border: Border.all(color: border, width: selected ? 2.1 : 1.4),
+          ),
+          child: Stack(
+            children: [
+              Center(
+                child: Text(
+                  c.label,
+                  textAlign: TextAlign.center,
+                  style: TextStyle(
+                    color: Colors.white,
+                    fontWeight: FontWeight.w900,
+                    fontSize: isJp ? 18 : 18,
+                    height: 1.2,
+                  ),
+                ),
+              ),
+              if (isJp)
+                Positioned(
+                  top: 2,
+                  right: 2,
+                  child: Container(
+                    padding: const EdgeInsets.all(4),
+                    decoration: BoxDecoration(
+                      color: Colors.white.withValues(alpha: 0.18),
+                      shape: BoxShape.circle,
+                    ),
+                    child: const Icon(Icons.volume_up_rounded,
+                        size: 12, color: Colors.white),
+                  ),
+                ),
+              if (matched)
+                const Positioned(
+                  top: 2,
+                  left: 2,
+                  child: Icon(Icons.check_circle_rounded,
+                      size: 16, color: Color(0xFF10B981)),
+                ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final progress =
+        _jpColumn.isEmpty ? 0.0 : _matchedKeys.length / _jpColumn.length;
+    final elapsed = _formatDuration(_stopwatch.elapsed);
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(16, 0, 16, 16),
+      child: Stack(
+        clipBehavior: Clip.none,
+        children: [
+          Align(
+            alignment: Alignment.topCenter,
+            child: IgnorePointer(
+              child: SizedBox(
+                height: 130,
+                width: double.infinity,
+                child: ConfettiWidget(
+                  confettiController: _confetti,
+                  blastDirectionality: BlastDirectionality.explosive,
+                  maxBlastForce: 14,
+                  minBlastForce: 6,
+                  emissionFrequency: 0.08,
+                  numberOfParticles: 12,
+                  gravity: 0.22,
+                  shouldLoop: false,
+                  colors: const [
+                    Color(0xFFFFE000),
+                    Color(0xFF10B981),
+                    Color(0xFFFF8A34),
+                    Color(0xFF3B82F6),
+                  ],
+                ),
+              ),
+            ),
+          ),
+          Column(children: [
+            Container(
+              padding: const EdgeInsets.all(14),
+              decoration: _card(),
+              child: Column(
+                children: [
+                  Row(
+                    children: [
+                      const Icon(Icons.link_rounded,
+                          color: Color(0xFFFFE000)),
+                      const SizedBox(width: 8),
+                      const Expanded(
+                        child: Text('জাপানি ↔ বাংলা দিন মিলাও',
+                            style: TextStyle(
+                                color: Colors.white,
+                                fontWeight: FontWeight.w900)),
+                      ),
+                      _WeekStatChip(label: 'XP', value: '$_xp'),
+                      const SizedBox(width: 6),
+                      _WeekStatChip(label: 'স্ট্রিক', value: '$_streak'),
+                    ],
+                  ),
+                  const SizedBox(height: 8),
+                  Row(
+                    children: [
+                      Icon(Icons.timer_rounded,
+                          size: 14,
+                          color: Colors.white.withValues(alpha: 0.7)),
+                      const SizedBox(width: 4),
+                      Text(elapsed,
+                          style: TextStyle(
+                              color: Colors.white.withValues(alpha: 0.85),
+                              fontWeight: FontWeight.w800,
+                              fontSize: 12)),
+                      const SizedBox(width: 14),
+                      Text('মুভ: $_moves',
+                          style: TextStyle(
+                              color: Colors.white.withValues(alpha: 0.85),
+                              fontWeight: FontWeight.w800,
+                              fontSize: 12)),
+                      const Spacer(),
+                      Text(
+                          '${_matchedKeys.length}/${_jpColumn.length} মিলেছে',
+                          style: const TextStyle(
+                              color: Color(0xFFFFE000),
+                              fontWeight: FontWeight.w900,
+                              fontSize: 12)),
+                    ],
+                  ),
+                  const SizedBox(height: 8),
+                  LinearProgressIndicator(
+                    minHeight: 7,
+                    borderRadius: BorderRadius.circular(99),
+                    value: progress.clamp(0, 1),
+                    backgroundColor: Colors.white.withValues(alpha: 0.12),
+                    valueColor:
+                        const AlwaysStoppedAnimation(Color(0xFFFFE000)),
+                  ),
+                ],
+              ),
+            ),
+            const SizedBox(height: 10),
+            Expanded(
+              child: Row(
+                children: [
+                  Expanded(
+                    child: ListView.separated(
+                      physics: const BouncingScrollPhysics(),
+                      itemCount: _jpColumn.length,
+                      separatorBuilder: (_, __) => const SizedBox(height: 10),
+                      itemBuilder: (_, i) =>
+                          _buildCard(_jpColumn[i], i, true),
+                    ),
+                  ),
+                  const SizedBox(width: 10),
+                  Expanded(
+                    child: ListView.separated(
+                      physics: const BouncingScrollPhysics(),
+                      itemCount: _bnColumn.length,
+                      separatorBuilder: (_, __) => const SizedBox(height: 10),
+                      itemBuilder: (_, i) =>
+                          _buildCard(_bnColumn[i], i, false),
+                    ),
+                  ),
+                ],
+              ),
+            ),
+            SizedBox(
+              width: double.infinity,
+              child: OutlinedButton.icon(
+                onPressed: _reset,
+                style: OutlinedButton.styleFrom(
+                    side: BorderSide(
+                        color: Colors.white.withValues(alpha: 0.2)),
+                    foregroundColor: Colors.white),
+                icon: const Icon(Icons.refresh_rounded),
+                label: const Text('রি-স্টার্ট',
+                    style: TextStyle(fontWeight: FontWeight.w900)),
+              ),
+            ),
+          ]),
+        ],
+      ),
+    );
+  }
+}
+
+class _WeekSequenceGame extends StatefulWidget {
+  const _WeekSequenceGame({super.key});
+
+  @override
+  State<_WeekSequenceGame> createState() => _WeekSequenceGameState();
+}
+
+class _WeekSequenceGameState extends State<_WeekSequenceGame>
+    with TickerProviderStateMixin {
+  final _rng = math.Random();
+  final _tts = FlutterTts();
+  late ConfettiController _confetti;
+  late AnimationController _shakeCtrl;
+  Timer? _timer;
+  static const _totalRounds = 10;
+  static const _totalSeconds = 60;
+  static const _sessionXpBonus = 50;
+
+  int _round = 1;
+  int _timeLeft = _totalSeconds;
+  int _score = 0;
+  int _streak = 0;
+  int _bestStreak = 0;
+  int _attempts = 0;
+  int _correct = 0;
+  bool _ttsReady = false;
+  bool _slowMode = false;
+  final Map<String, int> _missed = {};
+  late _Weekday _current;
+  late _Weekday _correctNext;
+  late List<_Weekday> _options;
+  String? _picked;
+
+  @override
+  void initState() {
+    super.initState();
+    _confetti = ConfettiController(duration: const Duration(milliseconds: 650));
+    _shakeCtrl = AnimationController(
+        vsync: this, duration: const Duration(milliseconds: 380));
+    _initTts();
+    _buildRound(reset: true);
+    _startTimer();
+  }
+
+  Future<void> _initTts() async {
+    try {
+      await _tts.setLanguage('ja-JP');
+      await _tts.setSpeechRate(_slowMode ? 0.32 : 0.50);
+      await _tts.setPitch(1.05);
+      if (!mounted) return;
+      setState(() => _ttsReady = true);
+      // ignore: discarded_futures
+      _speak();
+    } catch (_) {}
+  }
+
+  Future<void> _speak() async {
+    if (!_ttsReady) return;
+    await _tts.stop();
+    await _tts.setSpeechRate(_slowMode ? 0.32 : 0.50);
+    await _tts.speak(_current.kana);
+  }
+
+  void _startTimer() {
+    _timer?.cancel();
+    _timer = Timer.periodic(const Duration(seconds: 1), (timer) {
+      if (!mounted) return;
+      if (_timeLeft <= 1) {
+        timer.cancel();
+        _showResult();
+      } else {
+        setState(() => _timeLeft -= 1);
+      }
+    });
+  }
+
+  void _buildRound({bool reset = false}) {
+    if (reset) {
+      _round = 1;
+      _score = 0;
+      _streak = 0;
+      _bestStreak = 0;
+      _timeLeft = _totalSeconds;
+      _attempts = 0;
+      _correct = 0;
+      _missed.clear();
+    }
+    final idx = _rng.nextInt(_weekdays.length);
+    final now = _weekdays[idx];
+    final next = _weekdays[(idx + 1) % _weekdays.length];
+    final pool =
+        _weekdays.where((d) => d.jp != next.jp).toList()..shuffle(_rng);
+    setState(() {
+      _current = now;
+      _correctNext = next;
+      _options = [next, ...pool.take(3)]..shuffle(_rng);
+      _picked = null;
+    });
+    if (_ttsReady) {
+      // ignore: discarded_futures
+      _speak();
+    }
+  }
+
+  void _pick(_Weekday day) {
+    if (_picked != null) return;
+    final ok = day.jp == _correctNext.jp;
+    setState(() {
+      _picked = day.jp;
+      _attempts += 1;
+      if (ok) {
+        _streak += 1;
+        if (_streak > _bestStreak) _bestStreak = _streak;
+        _score += 10;
+        _correct += 1;
+      } else {
+        _streak = 0;
+        _missed[_correctNext.jp] = (_missed[_correctNext.jp] ?? 0) + 1;
+      }
+    });
+    if (ok) {
+      HapticFeedback.mediumImpact();
+      _confetti.play();
+    } else {
+      HapticFeedback.heavyImpact();
+      _shakeCtrl.forward(from: 0);
+    }
+    Future.delayed(const Duration(milliseconds: 500), () {
+      if (!mounted) return;
+      if (_round >= _totalRounds) {
+        _showResult();
+      } else {
+        _round += 1;
+        _buildRound();
+      }
+    });
+  }
+
+  void _showResult() {
+    _timer?.cancel();
+    _showWeekAwesomeResult(
+      context: context,
+      title: 'নেক্সট ডে — রেজাল্ট',
+      scoreLabel: 'XP: ${_score + _sessionXpBonus}',
+      stats: [
+        'রাউন্ড: $_round/$_totalRounds',
+        'চেষ্টা: $_attempts',
+        'সঠিক: $_correct',
+        'নির্ভুলতা: ${_attempts == 0 ? 0 : ((_correct * 100) / _attempts).round()}%',
+        'সেরা স্ট্রিক: $_bestStreak',
+        'সেশন বোনাস: +$_sessionXpBonus XP',
+      ],
+      missed: _missed.entries.toList()
+        ..sort((a, b) => b.value.compareTo(a.value)),
+      onPlayAgain: () {
+        _buildRound(reset: true);
+        _startTimer();
+      },
+    );
+  }
+
+  @override
+  void dispose() {
+    _timer?.cancel();
+    _confetti.dispose();
+    _shakeCtrl.dispose();
+    _tts.stop();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final timeProgress = _timeLeft / _totalSeconds;
+    final roundProgress = _round / _totalRounds;
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(16, 0, 16, 16),
+      child: Stack(
+        clipBehavior: Clip.none,
+        children: [
+          Align(
+            alignment: Alignment.topCenter,
+            child: IgnorePointer(
+              child: SizedBox(
+                height: 130,
+                width: double.infinity,
+                child: ConfettiWidget(
+                  confettiController: _confetti,
+                  blastDirectionality: BlastDirectionality.explosive,
+                  maxBlastForce: 14,
+                  minBlastForce: 6,
+                  emissionFrequency: 0.08,
+                  numberOfParticles: 12,
+                  gravity: 0.22,
+                  shouldLoop: false,
+                  colors: const [
+                    Color(0xFFFFE000),
+                    Color(0xFF10B981),
+                    Color(0xFFFF8A34),
+                    Color(0xFF3B82F6),
+                  ],
+                ),
+              ),
+            ),
+          ),
+          Column(
+            children: [
+              Container(
+                width: double.infinity,
+                padding: const EdgeInsets.all(14),
+                decoration: _card(),
+                child: Column(
+                  children: [
+                    Row(
+                      children: [
+                        const Icon(Icons.speed_rounded,
+                            color: Color(0xFFFFE000)),
+                        const SizedBox(width: 8),
+                        Text('রাউন্ড: $_round/$_totalRounds',
+                            style: const TextStyle(
+                                color: Colors.white,
+                                fontWeight: FontWeight.w900)),
+                        const SizedBox(width: 10),
+                        _WeekStatChip(label: 'স্কোর', value: '$_score'),
+                        const SizedBox(width: 6),
+                        _WeekStatChip(label: 'সেরা', value: '$_bestStreak'),
+                        const Spacer(),
+                        Icon(Icons.timer_rounded,
+                            size: 16,
+                            color: _timeLeft <= 5
+                                ? const Color(0xFFFF6B6B)
+                                : const Color(0xFFFFE000)),
+                        const SizedBox(width: 4),
+                        Text('${_timeLeft}s',
+                            style: TextStyle(
+                                color: _timeLeft <= 5
+                                    ? const Color(0xFFFFB4B4)
+                                    : const Color(0xFFFFE000),
+                                fontWeight: FontWeight.w900)),
+                      ],
+                    ),
+                    const SizedBox(height: 8),
+                    LinearProgressIndicator(
+                      minHeight: 6,
+                      borderRadius: BorderRadius.circular(99),
+                      value: roundProgress.clamp(0, 1),
+                      backgroundColor: Colors.white.withValues(alpha: 0.12),
+                      valueColor:
+                          const AlwaysStoppedAnimation(Color(0xFFFFE000)),
+                    ),
+                    const SizedBox(height: 4),
+                    LinearProgressIndicator(
+                      minHeight: 5,
+                      borderRadius: BorderRadius.circular(99),
+                      value: timeProgress.clamp(0, 1),
+                      backgroundColor: Colors.white.withValues(alpha: 0.10),
+                      valueColor: AlwaysStoppedAnimation(_timeLeft <= 5
+                          ? const Color(0xFFFF6B6B)
+                          : const Color(0xFF3B82F6)),
+                    ),
+                  ],
+                ),
+              ),
+              const SizedBox(height: 10),
+              AnimatedBuilder(
+                animation: _shakeCtrl,
+                builder: (_, child) {
+                  final wrong = _picked != null && _picked != _correctNext.jp;
+                  final dx = wrong
+                      ? math.sin(_shakeCtrl.value * math.pi * 6) * 8
+                      : 0.0;
+                  return Transform.translate(
+                      offset: Offset(dx, 0), child: child);
+                },
+                child: Container(
+                  width: double.infinity,
+                  padding: const EdgeInsets.all(16),
+                  decoration: _card(radius: 18),
+                  child: Column(
+                    children: [
+                      const Text('এই দিনের পরের দিন কোনটি?',
+                          style: TextStyle(
+                              color: Colors.white,
+                              fontWeight: FontWeight.w900)),
+                      const SizedBox(height: 10),
+                      Text(_current.jp,
+                          style: const TextStyle(
+                              color: Color(0xFFFFE000),
+                              fontWeight: FontWeight.w900,
+                              fontSize: 44)),
+                      Text('${_current.kana} • ${_current.bnPronunciation}',
+                          style: TextStyle(
+                              color: Colors.white.withValues(alpha: 0.84),
+                              fontWeight: FontWeight.w700)),
+                      const SizedBox(height: 10),
+                      Row(
+                        mainAxisAlignment: MainAxisAlignment.center,
+                        children: [
+                          GestureDetector(
+                            onTap: _speak,
+                            child: Container(
+                              padding: const EdgeInsets.symmetric(
+                                  horizontal: 12, vertical: 6),
+                              decoration: BoxDecoration(
+                                color: const Color(0xFFFFE000)
+                                    .withValues(alpha: 0.18),
+                                borderRadius: BorderRadius.circular(99),
+                                border: Border.all(
+                                    color: const Color(0xFFFFE000)
+                                        .withValues(alpha: 0.6)),
+                              ),
+                              child: const Row(
+                                mainAxisSize: MainAxisSize.min,
+                                children: [
+                                  Icon(Icons.volume_up_rounded,
+                                      color: Color(0xFFFFE000), size: 16),
+                                  SizedBox(width: 4),
+                                  Text('শুনি',
+                                      style: TextStyle(
+                                          color: Color(0xFFFFE000),
+                                          fontWeight: FontWeight.w900,
+                                          fontSize: 12)),
+                                ],
+                              ),
+                            ),
+                          ),
+                          const SizedBox(width: 8),
+                          GestureDetector(
+                            onTap: () async {
+                              setState(() => _slowMode = !_slowMode);
+                              await _speak();
+                            },
+                            child: Container(
+                              padding: const EdgeInsets.symmetric(
+                                  horizontal: 12, vertical: 6),
+                              decoration: BoxDecoration(
+                                color: _slowMode
+                                    ? const Color(0xFFFFE000)
+                                    : Colors.white.withValues(alpha: 0.10),
+                                borderRadius: BorderRadius.circular(99),
+                                border: Border.all(
+                                    color:
+                                        Colors.white.withValues(alpha: 0.2)),
+                              ),
+                              child: Row(
+                                mainAxisSize: MainAxisSize.min,
+                                children: [
+                                  Icon(Icons.pets_rounded,
+                                      color: _slowMode
+                                          ? const Color(0xFF1E293B)
+                                          : Colors.white,
+                                      size: 16),
+                                  const SizedBox(width: 4),
+                                  Text('ধীরে',
+                                      style: TextStyle(
+                                          color: _slowMode
+                                              ? const Color(0xFF1E293B)
+                                              : Colors.white,
+                                          fontWeight: FontWeight.w900,
+                                          fontSize: 12)),
+                                ],
+                              ),
+                            ),
+                          ),
+                        ],
+                      ),
+                    ],
+                  ),
+                ),
+              ),
+              const SizedBox(height: 10),
+              Expanded(
+                child: ListView.separated(
+                  itemCount: _options.length,
+                  separatorBuilder: (_, __) => const SizedBox(height: 10),
+                  itemBuilder: (_, i) {
+                    final o = _options[i];
+                    final picked = _picked == o.jp;
+                    final correct = o.jp == _correctNext.jp;
+                    final bg = _picked == null
+                        ? Colors.white.withValues(alpha: 0.06)
+                        : (correct
+                            ? const Color(0xFF10B981).withValues(alpha: 0.22)
+                            : (picked
+                                ? const Color(0xFFEF4444)
+                                    .withValues(alpha: 0.22)
+                                : Colors.white.withValues(alpha: 0.05)));
+                    final border = _picked == null
+                        ? Colors.white.withValues(alpha: 0.16)
+                        : (correct
+                            ? const Color(0xFF10B981)
+                            : (picked
+                                ? const Color(0xFFEF4444)
+                                : Colors.white.withValues(alpha: 0.16)));
+                    return GestureDetector(
+                      onTap: () => _pick(o),
+                      child: AnimatedScale(
+                        scale: picked && correct ? 1.03 : 1.0,
+                        duration: const Duration(milliseconds: 220),
+                        child: Container(
+                          padding: const EdgeInsets.all(14),
+                          decoration: BoxDecoration(
+                            color: bg,
+                            borderRadius: BorderRadius.circular(14),
+                            border: Border.all(
+                                color: border, width: _picked == null ? 1 : 2),
+                          ),
+                          child: Row(
+                            children: [
+                              if (picked || (correct && _picked != null))
+                                Padding(
+                                  padding: const EdgeInsets.only(right: 8),
+                                  child: Icon(
+                                    correct
+                                        ? Icons.check_circle_rounded
+                                        : Icons.cancel_rounded,
+                                    color: correct
+                                        ? const Color(0xFF10B981)
+                                        : const Color(0xFFEF4444),
+                                    size: 20,
+                                  ),
+                                ),
+                              Expanded(
+                                child: Text(
+                                    '${o.jp}  (${o.bnPronunciation})',
+                                    textAlign: TextAlign.center,
+                                    style: const TextStyle(
+                                        color: Colors.white,
+                                        fontWeight: FontWeight.w900,
+                                        fontSize: 22)),
+                              ),
+                            ],
+                          ),
+                        ),
+                      ),
+                    );
+                  },
+                ),
+              ),
+            ],
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+// ═════════════════════════════════════════════════════════════════════
+// শুনে বলো — Listening MCQ: TTS plays JP, pick Bengali day name
+// ═════════════════════════════════════════════════════════════════════
+
+class _WeekListenGame extends StatefulWidget {
+  const _WeekListenGame({super.key});
+  @override
+  State<_WeekListenGame> createState() => _WeekListenGameState();
+}
+
+class _WeekListenGameState extends State<_WeekListenGame>
+    with TickerProviderStateMixin {
+  static const _teal = Color(0xFF14B8A6);
+  static const _totalRounds = 8;
+  static const _sessionXpBonus = 50;
+
+  final _rng = math.Random();
+  final _tts = FlutterTts();
+  late final Future<void> _ttsReady;
+  late ConfettiController _confetti;
+  late AnimationController _shakeCtrl;
+
+  late _Weekday _target;
+  late List<_Weekday> _options;
+  int _roundIdx = 0;
+  int? _pickedIdx;
+  bool _locked = false;
+  bool _slowMode = false;
+  bool _showCorrectBanner = false;
+
+  final Stopwatch _sessionTimer = Stopwatch();
+  int _correct = 0;
+  int _totalAttempts = 0;
+  int _xp = 0;
+  int _streak = 0;
+  int _bestStreak = 0;
+  final Map<int, int> _missed = {};
+
+  @override
+  void initState() {
+    super.initState();
+    _confetti = ConfettiController(duration: const Duration(milliseconds: 650));
+    _shakeCtrl = AnimationController(
+        vsync: this, duration: const Duration(milliseconds: 420));
+    _ttsReady = _initTts();
+    _newSession();
+  }
+
+  Future<void> _initTts() async {
+    await _tts.awaitSpeakCompletion(true);
+    await _tts.setLanguage('ja-JP');
+    await _tts.setSpeechRate(0.46);
+    await _tts.setPitch(1.05);
+    await _tts.setVolume(1.0);
+  }
+
+  Future<void> _applyRate() async {
+    await _ttsReady;
+    await _tts.setSpeechRate(_slowMode ? 0.30 : 0.46);
+  }
+
+  Future<void> _speak() async {
+    await _ttsReady;
+    await _tts.stop();
+    await _tts.speak(_target.kana);
+  }
+
+  List<int> _deck = [];
+  int? _lastTargetIdx;
+
+  void _newSession() {
+    _roundIdx = 0;
+    _correct = 0;
+    _totalAttempts = 0;
+    _xp = 0;
+    _streak = 0;
+    _bestStreak = 0;
+    _missed.clear();
+    _deck = [];
+    _lastTargetIdx = null;
+    _sessionTimer
+      ..reset()
+      ..start();
+    _buildRound();
+    WidgetsBinding.instance.addPostFrameCallback((_) => _speak());
+  }
+
+  int _drawTargetIdx() {
+    if (_deck.isEmpty) {
+      _deck = List<int>.generate(_weekdays.length, (i) => i)..shuffle(_rng);
+      if (_lastTargetIdx != null &&
+          _deck.length > 1 &&
+          _deck.first == _lastTargetIdx) {
+        _deck.add(_deck.removeAt(0));
+      }
+    }
+    final idx = _deck.removeAt(0);
+    _lastTargetIdx = idx;
+    return idx;
+  }
+
+  void _buildRound() {
+    final targetIdx = _drawTargetIdx();
+    _target = _weekdays[targetIdx];
+    final pool = List<int>.generate(_weekdays.length, (i) => i)
+        .where((i) => i != targetIdx)
+        .toList()
+      ..shuffle(_rng);
+    final selected = <int>{targetIdx, ...pool.take(3)};
+    final shuffledIdx = selected.toList()..shuffle(_rng);
+    setState(() {
+      _options = shuffledIdx.map((i) => _weekdays[i]).toList();
+      _locked = false;
+      _pickedIdx = null;
+      _showCorrectBanner = false;
+    });
+  }
+
+  String _fmt(Duration d) {
+    final m = d.inMinutes.remainder(60).toString().padLeft(2, '0');
+    final s = d.inSeconds.remainder(60).toString().padLeft(2, '0');
+    return '$m:$s';
+  }
+
+  void _pick(int idx) {
+    if (_locked) return;
+    final o = _options[idx];
+    _totalAttempts += 1;
+    final ok = o.bn == _target.bn;
+    setState(() {
+      _locked = true;
+      _pickedIdx = idx;
+    });
+    if (ok) {
+      HapticFeedback.mediumImpact();
+      setState(() {
+        _correct += 1;
+        _streak += 1;
+        if (_streak > _bestStreak) _bestStreak = _streak;
+        _xp += 10;
+        _showCorrectBanner = true;
+      });
+      _confetti.play();
+      Future.delayed(const Duration(milliseconds: 1200), () {
+        if (!mounted) return;
+        if (_roundIdx >= _totalRounds - 1) {
+          _sessionTimer.stop();
+          _xp += _sessionXpBonus;
+          _showEnd();
+        } else {
+          _roundIdx += 1;
+          _buildRound();
+          _speak();
+        }
+      });
+    } else {
+      HapticFeedback.heavyImpact();
+      setState(() {
+        _streak = 0;
+        final ti = _weekdays.indexOf(_target);
+        _missed[ti] = (_missed[ti] ?? 0) + 1;
+      });
+      _shakeCtrl.forward(from: 0);
+      Future.delayed(const Duration(milliseconds: 700), () {
+        if (!mounted) return;
+        setState(() {
+          _pickedIdx = null;
+          _locked = false;
+        });
+      });
+    }
+  }
+
+  void _showEnd() {
+    final acc = _totalAttempts == 0 ? 0 : ((_correct * 100) / _totalAttempts).round();
+    showModalBottomSheet<void>(
+      context: context,
+      backgroundColor: Colors.transparent,
+      isScrollControlled: true,
+      builder: (_) => _WeekAwesomeResultSheet(
+        title: 'শুনে বলো — সেশন শেষ',
+        scoreLabel: 'মোট XP: $_xp',
+        stats: [
+          'সঠিক: $_correct/$_totalRounds',
+          'নির্ভুলতা: $acc%',
+          'সেরা স্ট্রিক: $_bestStreak',
+          'সময়: ${_fmt(_sessionTimer.elapsed)}',
+        ],
+        missed: _missed.entries.map((e) {
+          final w = _weekdays[e.key];
+          return '${w.bnPronunciation} — ${w.bn}  ×${e.value}';
+        }).toList(),
+        onPlayAgain: () {
+          Navigator.of(context, rootNavigator: true).maybePop();
+          _newSession();
+        },
+      ),
+    );
+  }
+
+  @override
+  void dispose() {
+    _confetti.dispose();
+    _shakeCtrl.dispose();
+    _tts.stop();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final progress = (_roundIdx + 1) / _totalRounds;
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(16, 0, 16, 16),
+      child: Stack(
+        clipBehavior: Clip.none,
+        children: [
+          _WeekConfettiOverlay(controller: _confetti, accent: _teal),
+          Column(
+            children: [
+              _WeekHeaderPanel(
+                color: _teal,
+                title: 'শুনে বলো — অডিও শুনে বার বাছুন',
+                progress: progress,
+                roundText: 'রাউন্ড ${_roundIdx + 1}/$_totalRounds',
+                xp: _xp,
+                streak: _streak,
+                timer: _fmt(_sessionTimer.elapsed),
+              ),
+              const SizedBox(height: 12),
+              AnimatedBuilder(
+                animation: _shakeCtrl,
+                builder: (context, child) {
+                  final t = _shakeCtrl.value;
+                  final dx = math.sin(t * math.pi * 6) * 10 * (1 - t);
+                  return Transform.translate(offset: Offset(dx, 0), child: child);
+                },
+                child: Container(
+                  width: double.infinity,
+                  padding: const EdgeInsets.all(18),
+                  decoration: BoxDecoration(
+                    color: const Color(0xFF1E293B),
+                    borderRadius: BorderRadius.circular(20),
+                    border: Border.all(color: _teal.withValues(alpha: 0.55), width: 2),
+                    boxShadow: [
+                      BoxShadow(
+                        color: _teal.withValues(alpha: 0.18),
+                        blurRadius: 22,
+                        offset: const Offset(0, 8),
+                      ),
+                    ],
+                  ),
+                  child: Column(
+                    children: [
+                      Container(
+                        padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 6),
+                        decoration: BoxDecoration(
+                          color: _teal.withValues(alpha: 0.15),
+                          borderRadius: BorderRadius.circular(99),
+                        ),
+                        child: const Text('অডিও শুনুন',
+                            style: TextStyle(
+                              color: _teal,
+                              fontSize: 12,
+                              fontWeight: FontWeight.w900,
+                              letterSpacing: 1.2,
+                            )),
+                      ),
+                      const SizedBox(height: 14),
+                      Text(
+                        _target.bnPronunciation,
+                        style: const TextStyle(
+                          color: Color(0xFFFFE000),
+                          fontSize: 28,
+                          fontWeight: FontWeight.w900,
+                        ),
+                      ),
+                      const SizedBox(height: 14),
+                      Row(
+                        children: [
+                          Expanded(
+                            child: ElevatedButton.icon(
+                              onPressed: _locked ? null : _speak,
+                              style: ElevatedButton.styleFrom(
+                                backgroundColor: _teal,
+                                foregroundColor: Colors.white,
+                                padding: const EdgeInsets.symmetric(vertical: 12),
+                                shape: RoundedRectangleBorder(
+                                    borderRadius: BorderRadius.circular(12)),
+                              ),
+                              icon: const Icon(Icons.volume_up_rounded),
+                              label: const Text('আবার শুনুন',
+                                  style: TextStyle(fontWeight: FontWeight.w900)),
+                            ),
+                          ),
+                          const SizedBox(width: 10),
+                          Expanded(
+                            child: OutlinedButton.icon(
+                              onPressed: _locked
+                                  ? null
+                                  : () async {
+                                      setState(() => _slowMode = !_slowMode);
+                                      await _applyRate();
+                                      await _speak();
+                                    },
+                              style: OutlinedButton.styleFrom(
+                                foregroundColor: _slowMode ? _teal : Colors.white,
+                                side: BorderSide(
+                                    color: _slowMode
+                                        ? _teal
+                                        : Colors.white.withValues(alpha: 0.28)),
+                                padding: const EdgeInsets.symmetric(vertical: 12),
+                                shape: RoundedRectangleBorder(
+                                    borderRadius: BorderRadius.circular(12)),
+                              ),
+                              icon: Icon(_slowMode
+                                  ? Icons.speed_rounded
+                                  : Icons.hourglass_bottom_rounded),
+                              label: Text(_slowMode ? 'স্বাভাবিক' : 'ধীর শোনা',
+                                  style: const TextStyle(fontWeight: FontWeight.w900)),
+                            ),
+                          ),
+                        ],
+                      ),
+                    ],
+                  ),
+                ),
+              ),
+              const SizedBox(height: 14),
+              const Text(
+                'এই বারের বাংলা নাম কোনটি?',
+                style: TextStyle(
+                  color: Colors.white,
+                  fontSize: 14,
+                  fontWeight: FontWeight.w900,
+                ),
+              ),
+              const SizedBox(height: 10),
+              Expanded(
+                child: Column(
+                  children: [
+                    for (int i = 0; i < _options.length; i++) ...[
+                      if (i != 0) const SizedBox(height: 10),
+                      _WeekOptionTile(
+                        label: _options[i].bn,
+                        sublabel: _options[i].bnPronunciation,
+                        picked: _pickedIdx == i,
+                        isCorrect: _options[i].bn == _target.bn,
+                        revealed: _pickedIdx != null,
+                        onTap: _locked ? null : () => _pick(i),
+                      ),
+                    ],
+                  ],
+                ),
+              ),
+            ],
+          ),
+          _WeekCorrectBanner(
+            visible: _showCorrectBanner,
+            streak: _streak,
+            text: '${_target.bnPronunciation} → ${_target.bn}',
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+// ═════════════════════════════════════════════════════════════════════
+// পড়ে বলো — Reading MCQ: BN day → JP (BN pronunciation) + Heijitsu/Shumatsu concepts
+// ═════════════════════════════════════════════════════════════════════
+
+class _WeekReadGame extends StatefulWidget {
+  const _WeekReadGame({super.key});
+  @override
+  State<_WeekReadGame> createState() => _WeekReadGameState();
+}
+
+class _WeekReadGameState extends State<_WeekReadGame>
+    with TickerProviderStateMixin {
+  static const _violet = Color(0xFF8B5CF6);
+  static const _totalRounds = 8;
+  static const _sessionXpBonus = 50;
+
+  final _rng = math.Random();
+  late ConfettiController _confetti;
+  late AnimationController _shakeCtrl;
+  late AnimationController _cardCtrl;
+
+  bool _isConcept = false;
+  late _WeekConcept _concept;
+  late _Weekday _target;
+  late List<String> _options;
+  late int _correctOptionIdx;
+  int _roundIdx = 0;
+  int? _pickedIdx;
+  bool _locked = false;
+  bool _showCorrectBanner = false;
+  bool _showExplanation = false;
+
+  final Stopwatch _sessionTimer = Stopwatch();
+  int _correct = 0;
+  int _totalAttempts = 0;
+  int _xp = 0;
+  int _streak = 0;
+  int _bestStreak = 0;
+  final Map<String, int> _missed = {};
+
+  @override
+  void initState() {
+    super.initState();
+    _confetti = ConfettiController(duration: const Duration(milliseconds: 650));
+    _shakeCtrl = AnimationController(
+        vsync: this, duration: const Duration(milliseconds: 420));
+    _cardCtrl = AnimationController(
+        vsync: this, duration: const Duration(milliseconds: 380));
+    _newSession();
+  }
+
+  List<int> _dayDeck = [];
+  List<int> _conceptDeck = [];
+  int? _lastDayIdx;
+  int? _lastConceptIdx;
+
+  void _newSession() {
+    _roundIdx = 0;
+    _correct = 0;
+    _totalAttempts = 0;
+    _xp = 0;
+    _streak = 0;
+    _bestStreak = 0;
+    _missed.clear();
+    _dayDeck = [];
+    _conceptDeck = [];
+    _lastDayIdx = null;
+    _lastConceptIdx = null;
+    _sessionTimer
+      ..reset()
+      ..start();
+    _buildRound();
+  }
+
+  int _drawDayIdx() {
+    if (_dayDeck.isEmpty) {
+      _dayDeck = List<int>.generate(_weekdays.length, (i) => i)..shuffle(_rng);
+      if (_lastDayIdx != null &&
+          _dayDeck.length > 1 &&
+          _dayDeck.first == _lastDayIdx) {
+        _dayDeck.add(_dayDeck.removeAt(0));
+      }
+    }
+    final idx = _dayDeck.removeAt(0);
+    _lastDayIdx = idx;
+    return idx;
+  }
+
+  int _drawConceptIdx() {
+    if (_conceptDeck.isEmpty) {
+      _conceptDeck =
+          List<int>.generate(_weekConcepts.length, (i) => i)..shuffle(_rng);
+      if (_lastConceptIdx != null &&
+          _conceptDeck.length > 1 &&
+          _conceptDeck.first == _lastConceptIdx) {
+        _conceptDeck.add(_conceptDeck.removeAt(0));
+      }
+    }
+    final idx = _conceptDeck.removeAt(0);
+    _lastConceptIdx = idx;
+    return idx;
+  }
+
+  void _buildRound() {
+    // ~35% concept, 65% direct translation rounds.
+    _isConcept = _rng.nextInt(100) < 35;
+    if (_isConcept) {
+      _concept = _weekConcepts[_drawConceptIdx()];
+      // Shuffle the concept options while tracking the correct index.
+      final indexed = List<int>.generate(_concept.options.length, (i) => i)..shuffle(_rng);
+      _options = indexed.map((i) => _concept.options[i]).toList();
+      _correctOptionIdx = indexed.indexOf(_concept.correctIdx);
+    } else {
+      final targetIdx = _drawDayIdx();
+      _target = _weekdays[targetIdx];
+      final pool = List<int>.generate(_weekdays.length, (i) => i)
+          .where((i) => i != targetIdx)
+          .toList()
+        ..shuffle(_rng);
+      final selected = <int>{targetIdx, ...pool.take(3)}.toList()..shuffle(_rng);
+      _options = selected.map((i) => _weekdays[i].bnPronunciation).toList();
+      _correctOptionIdx = selected.indexOf(targetIdx);
+    }
+    setState(() {
+      _locked = false;
+      _pickedIdx = null;
+      _showCorrectBanner = false;
+      _showExplanation = false;
+    });
+    _cardCtrl.forward(from: 0);
+  }
+
+  String _fmt(Duration d) {
+    final m = d.inMinutes.remainder(60).toString().padLeft(2, '0');
+    final s = d.inSeconds.remainder(60).toString().padLeft(2, '0');
+    return '$m:$s';
+  }
+
+  String get _bannerText {
+    if (_isConcept) return _concept.options[_concept.correctIdx];
+    return '${_target.bn} → ${_target.bnPronunciation}';
+  }
+
+  String get _missKey {
+    if (_isConcept) return 'C:${_concept.prompt}';
+    return 'W:${_target.bn}';
+  }
+
+  void _pick(int idx) {
+    if (_locked) return;
+    _totalAttempts += 1;
+    final ok = idx == _correctOptionIdx;
+    setState(() {
+      _locked = true;
+      _pickedIdx = idx;
+    });
+    if (ok) {
+      HapticFeedback.mediumImpact();
+      setState(() {
+        _correct += 1;
+        _streak += 1;
+        if (_streak > _bestStreak) _bestStreak = _streak;
+        _xp += 10;
+        _showCorrectBanner = true;
+        _showExplanation = _isConcept;
+      });
+      _confetti.play();
+      Future.delayed(const Duration(milliseconds: 1500), () {
+        if (!mounted) return;
+        if (_roundIdx >= _totalRounds - 1) {
+          _sessionTimer.stop();
+          _xp += _sessionXpBonus;
+          _showEnd();
+        } else {
+          _roundIdx += 1;
+          _buildRound();
+        }
+      });
+    } else {
+      HapticFeedback.heavyImpact();
+      setState(() {
+        _streak = 0;
+        _missed[_missKey] = (_missed[_missKey] ?? 0) + 1;
+        if (_isConcept) _showExplanation = true;
+      });
+      _shakeCtrl.forward(from: 0);
+      Future.delayed(const Duration(milliseconds: 900), () {
+        if (!mounted) return;
+        setState(() {
+          _pickedIdx = null;
+          _locked = false;
+        });
+      });
+    }
+  }
+
+  void _showEnd() {
+    final acc = _totalAttempts == 0 ? 0 : ((_correct * 100) / _totalAttempts).round();
+    showModalBottomSheet<void>(
+      context: context,
+      backgroundColor: Colors.transparent,
+      isScrollControlled: true,
+      builder: (_) => _WeekAwesomeResultSheet(
+        title: 'পড়ে বলো — সেশন শেষ',
+        scoreLabel: 'মোট XP: $_xp',
+        stats: [
+          'সঠিক: $_correct/$_totalRounds',
+          'নির্ভুলতা: $acc%',
+          'সেরা স্ট্রিক: $_bestStreak',
+          'সময়: ${_fmt(_sessionTimer.elapsed)}',
+        ],
+        missed: _missed.entries.map((e) {
+          if (e.key.startsWith('W:')) {
+            final bn = e.key.substring(2);
+            final w = _weekdays.firstWhere((x) => x.bn == bn);
+            return '${w.bn} → ${w.bnPronunciation}  ×${e.value}';
+          }
+          return 'কনসেপ্ট: ${e.key.substring(2)}  ×${e.value}';
+        }).toList(),
+        onPlayAgain: () {
+          Navigator.of(context, rootNavigator: true).maybePop();
+          _newSession();
+        },
+      ),
+    );
+  }
+
+  @override
+  void dispose() {
+    _confetti.dispose();
+    _shakeCtrl.dispose();
+    _cardCtrl.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final progress = (_roundIdx + 1) / _totalRounds;
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(16, 0, 16, 16),
+      child: Stack(
+        clipBehavior: Clip.none,
+        children: [
+          _WeekConfettiOverlay(controller: _confetti, accent: _violet),
+          Column(
+            children: [
+              _WeekHeaderPanel(
+                color: _violet,
+                title: 'পড়ে বলো — পড়ে বুঝে সঠিক উত্তর',
+                progress: progress,
+                roundText: 'রাউন্ড ${_roundIdx + 1}/$_totalRounds',
+                xp: _xp,
+                streak: _streak,
+                timer: _fmt(_sessionTimer.elapsed),
+              ),
+              const SizedBox(height: 12),
+              AnimatedBuilder(
+                animation: _shakeCtrl,
+                builder: (context, child) {
+                  final t = _shakeCtrl.value;
+                  final dx = math.sin(t * math.pi * 6) * 10 * (1 - t);
+                  return Transform.translate(offset: Offset(dx, 0), child: child);
+                },
+                child: ScaleTransition(
+                  scale: Tween<double>(begin: 0.94, end: 1).animate(
+                      CurvedAnimation(parent: _cardCtrl, curve: Curves.easeOutBack)),
+                  child: Container(
+                    width: double.infinity,
+                    padding: const EdgeInsets.all(20),
+                    decoration: BoxDecoration(
+                      gradient: const LinearGradient(
+                        colors: [Color(0xFF1E293B), Color(0xFF111827)],
+                        begin: Alignment.topLeft,
+                        end: Alignment.bottomRight,
+                      ),
+                      borderRadius: BorderRadius.circular(20),
+                      border:
+                          Border.all(color: _violet.withValues(alpha: 0.55), width: 2),
+                      boxShadow: [
+                        BoxShadow(
+                          color: _violet.withValues(alpha: 0.22),
+                          blurRadius: 24,
+                          offset: const Offset(0, 8),
+                        ),
+                      ],
+                    ),
+                    child: Column(
+                      children: [
+                        Icon(
+                          _isConcept ? _concept.icon : Icons.calendar_month_rounded,
+                          color: _isConcept ? _concept.color : Colors.white,
+                          size: 44,
+                        ),
+                        const SizedBox(height: 8),
+                        if (_isConcept)
+                          Container(
+                            padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 4),
+                            decoration: BoxDecoration(
+                              color: _concept.color.withValues(alpha: 0.15),
+                              borderRadius: BorderRadius.circular(99),
+                              border: Border.all(color: _concept.color.withValues(alpha: 0.4)),
+                            ),
+                            child: Text(
+                              '🧠 কনসেপ্ট',
+                              style: TextStyle(
+                                color: _concept.color,
+                                fontWeight: FontWeight.w900,
+                                fontSize: 11,
+                              ),
+                            ),
+                          ),
+                        if (_isConcept) const SizedBox(height: 8),
+                        Text(
+                          _isConcept ? _concept.prompt : '${_target.bn} — জাপানিতে কী?',
+                          textAlign: TextAlign.center,
+                          style: const TextStyle(
+                            color: Colors.white,
+                            fontSize: 18,
+                            fontWeight: FontWeight.w900,
+                            height: 1.3,
+                          ),
+                        ),
+                        if (_showExplanation && _isConcept) ...[
+                          const SizedBox(height: 10),
+                          Container(
+                            padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+                            decoration: BoxDecoration(
+                              color: const Color(0xFF10B981).withValues(alpha: 0.12),
+                              borderRadius: BorderRadius.circular(10),
+                              border: Border.all(color: const Color(0xFF10B981).withValues(alpha: 0.5)),
+                            ),
+                            child: Text(
+                              _concept.explanation,
+                              textAlign: TextAlign.center,
+                              style: const TextStyle(
+                                color: Color(0xFF10B981),
+                                fontSize: 12,
+                                fontWeight: FontWeight.w700,
+                                height: 1.4,
+                              ),
+                            ),
+                          ),
+                        ],
+                      ],
+                    ),
+                  ),
+                ),
+              ),
+              const SizedBox(height: 14),
+              const Text(
+                'সঠিক উত্তর কোনটি?',
+                style: TextStyle(
+                  color: Colors.white,
+                  fontSize: 14,
+                  fontWeight: FontWeight.w900,
+                ),
+              ),
+              const SizedBox(height: 10),
+              Expanded(
+                child: Column(
+                  children: [
+                    for (int i = 0; i < _options.length; i++) ...[
+                      if (i != 0) const SizedBox(height: 8),
+                      _WeekOptionTile(
+                        label: _options[i],
+                        sublabel: '',
+                        picked: _pickedIdx == i,
+                        isCorrect: i == _correctOptionIdx,
+                        revealed: _pickedIdx != null,
+                        onTap: _locked ? null : () => _pick(i),
+                      ),
+                    ],
+                  ],
+                ),
+              ),
+            ],
+          ),
+          _WeekCorrectBanner(
+            visible: _showCorrectBanner,
+            streak: _streak,
+            text: _bannerText,
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+// ═════════════════════════════════════════════════════════════════════
+// বলে দেখাও — Speaking: Show BN day, user speaks JP, STT evaluates
+// ═════════════════════════════════════════════════════════════════════
+
+class _WeekSpeakGame extends StatefulWidget {
+  const _WeekSpeakGame({super.key});
+  @override
+  State<_WeekSpeakGame> createState() => _WeekSpeakGameState();
+}
+
+class _WeekSpeakGameState extends State<_WeekSpeakGame>
+    with TickerProviderStateMixin {
+  static const _rose = Color(0xFFE11D48);
+  static const _maxSeconds = 6;
+  static const _totalRounds = 7;
+  static const _sessionXpBonus = 50;
+
+  final _rng = math.Random();
+  final _tts = FlutterTts();
+  final _stt = SpeechToText();
+  bool _sttReady = false;
+  bool _ttsReady = false;
+  String? _locale;
+  String? _error;
+  bool _listening = false;
+  String _heard = '';
+  double _soundLevel = 0;
+  int _secondsLeft = 0;
+  Timer? _recordTimer;
+
+  late _Weekday _target;
+  int _roundIdx = 0;
+  int? _lastScore;
+  bool _evaluated = false;
+  bool _showHint = false;
+
+  late ConfettiController _confetti;
+  late AnimationController _pulseCtrl;
+  late AnimationController _shakeCtrl;
+
+  final Stopwatch _sessionTimer = Stopwatch();
+  int _correct = 0;
+  int _attempts = 0;
+  int _xp = 0;
+  int _streak = 0;
+  int _bestStreak = 0;
+  final Map<int, int> _missed = {};
+
+  @override
+  void initState() {
+    super.initState();
+    _confetti = ConfettiController(duration: const Duration(milliseconds: 700));
+    _pulseCtrl = AnimationController(
+        vsync: this, duration: const Duration(milliseconds: 1100))
+      ..repeat(reverse: true);
+    _shakeCtrl = AnimationController(
+        vsync: this, duration: const Duration(milliseconds: 420));
+    _sessionTimer.start();
+    _initTts();
+    _initStt();
+    _newRound();
+  }
+
+  Future<void> _initTts() async {
+    try {
+      await _tts.setLanguage('ja-JP');
+      await _tts.setSpeechRate(0.45);
+      if (mounted) setState(() => _ttsReady = true);
+    } catch (_) {}
+  }
+
+  Future<void> _initStt() async {
+    try {
+      final ok = await _stt.initialize(
+        onError: (e) {
+          if (!mounted) return;
+          setState(() => _error = e.errorMsg);
+        },
+        onStatus: (_) {},
+      );
+      if (!mounted) return;
+      if (!ok) {
+        setState(() => _sttReady = false);
+        return;
+      }
+      final locales = await _stt.locales();
+      final ja = locales.where((l) => l.localeId.toLowerCase().startsWith('ja'));
+      setState(() {
+        _locale = ja.isNotEmpty
+            ? ja.first.localeId
+            : (locales.isNotEmpty ? locales.first.localeId : null);
+        _sttReady = true;
+      });
+    } catch (e) {
+      if (!mounted) return;
+      setState(() {
+        _sttReady = false;
+        _error = '$e';
+      });
+    }
+  }
+
+  List<int> _speakDeck = [];
+  int? _lastSpeakIdx;
+
+  int _drawSpeakIdx() {
+    if (_speakDeck.isEmpty) {
+      _speakDeck = List<int>.generate(_weekdays.length, (i) => i)..shuffle(_rng);
+      if (_lastSpeakIdx != null &&
+          _speakDeck.length > 1 &&
+          _speakDeck.first == _lastSpeakIdx) {
+        _speakDeck.add(_speakDeck.removeAt(0));
+      }
+    }
+    final idx = _speakDeck.removeAt(0);
+    _lastSpeakIdx = idx;
+    return idx;
+  }
+
+  void _newRound() {
+    final idx = _drawSpeakIdx();
+    setState(() {
+      _target = _weekdays[idx];
+      _heard = '';
+      _lastScore = null;
+      _evaluated = false;
+      _showHint = false;
+      _error = null;
+    });
+  }
+
+  // Acceptable forms for each weekday (index = weekday list index).
+  static const _accepts = <int, List<String>>{
+    0: ['げつようび', 'getsuyoubi', 'getsuyobi', '月曜日', 'げつよう'],
+    1: ['かようび', 'kayoubi', 'kayobi', '火曜日', 'かよう'],
+    2: ['すいようび', 'suiyoubi', 'suiyobi', '水曜日', 'すいよう'],
+    3: ['もくようび', 'mokuyoubi', 'mokuyobi', '木曜日', 'もくよう'],
+    4: ['きんようび', 'kinyoubi', 'kinyobi', '金曜日', 'きんよう'],
+    5: ['どようび', 'doyoubi', 'doyobi', '土曜日', 'どよう'],
+    6: ['にちようび', 'nichiyoubi', 'nichiyobi', '日曜日', 'にちよう'],
+  };
+
+  static String _normJp(String s) {
+    var out = s.toLowerCase();
+    final buf = StringBuffer();
+    for (final r in out.runes) {
+      if (r >= 0xFF10 && r <= 0xFF19) {
+        buf.writeCharCode(r - 0xFF10 + 0x30);
+        continue;
+      }
+      if (r == 0x30FC) continue;
+      const smallToBig = {
+        0x3041: 0x3042, 0x3043: 0x3044, 0x3045: 0x3046,
+        0x3047: 0x3048, 0x3049: 0x304A,
+        0x30A1: 0x30A2, 0x30A3: 0x30A4, 0x30A5: 0x30A6,
+        0x30A7: 0x30A8, 0x30A9: 0x30AA,
+      };
+      if (r == 0x3001 || r == 0x3002 || r == 0x002E ||
+          r == 0x002C || r == 0x0020) continue;
+      buf.writeCharCode(smallToBig[r] ?? r);
+    }
+    return buf.toString();
+  }
+
+  int _grade(String raw, int targetIdx) {
+    final heard = _normJp(raw);
+    if (heard.isEmpty) return 0;
+    final accepts = (_accepts[targetIdx] ?? <String>[]).map(_normJp).toList();
+    for (final a in accepts) {
+      if (heard == a) return 100;
+    }
+    int best = 0;
+    for (final a in accepts) {
+      if (heard.contains(a) || a.contains(heard)) {
+        best = math.max(best, 92);
+      }
+      final sim = _similarity(heard, a);
+      best = math.max(best, (sim * 88).round());
+    }
+    return best.clamp(0, 100);
+  }
+
+  double _similarity(String a, String b) {
+    if (b.isEmpty) return 0;
+    int matches = 0;
+    final remaining = a.split('').toList();
+    for (final c in b.split('')) {
+      final idx = remaining.indexOf(c);
+      if (idx >= 0) {
+        matches++;
+        remaining.removeAt(idx);
+      }
+    }
+    return matches / b.length;
+  }
+
+  Future<void> _startListening() async {
+    if (_listening) return;
+    HapticFeedback.mediumImpact();
+    setState(() {
+      _heard = '';
+      _error = null;
+      _lastScore = null;
+      _evaluated = false;
+      _secondsLeft = _maxSeconds;
+      _soundLevel = 0;
+    });
+    try {
+      if (!_sttReady) await _initStt();
+      if (!_sttReady) {
+        throw Exception('Speech recognition এই ডিভাইসে কাজ করছে না।');
+      }
+      await _stt.listen(
+        localeId: _locale,
+        listenMode: ListenMode.confirmation,
+        partialResults: true,
+        cancelOnError: true,
+        listenFor: const Duration(seconds: _maxSeconds),
+        pauseFor: const Duration(seconds: 3),
+        onResult: (SpeechRecognitionResult r) {
+          if (!mounted) return;
+          setState(() => _heard = r.recognizedWords);
+        },
+        onSoundLevelChange: (level) {
+          if (!mounted) return;
+          setState(() => _soundLevel = level);
+        },
+      );
+      if (!mounted) return;
+      setState(() => _listening = true);
+      _recordTimer?.cancel();
+      _recordTimer = Timer.periodic(const Duration(seconds: 1), (_) async {
+        if (!mounted || !_listening) return;
+        if (_secondsLeft <= 1) {
+          await _stopAndCheck();
+          return;
+        }
+        setState(() => _secondsLeft -= 1);
+      });
+    } catch (e) {
+      if (!mounted) return;
+      _recordTimer?.cancel();
+      setState(() {
+        _listening = false;
+        _error = '$e';
+      });
+    }
+  }
+
+  Future<void> _stopAndCheck() async {
+    if (!_listening) return;
+    _recordTimer?.cancel();
+    HapticFeedback.selectionClick();
+    await _stt.stop();
+    if (!mounted) return;
+    setState(() {
+      _listening = false;
+      _secondsLeft = 0;
+      _soundLevel = 0;
+    });
+    final targetIdx = _weekdays.indexOf(_target);
+    final score = _grade(_heard, targetIdx);
+    final ok = score >= 75;
+    _attempts += 1;
+    setState(() {
+      _lastScore = score;
+      _evaluated = true;
+      if (ok) {
+        _correct += 1;
+        _streak += 1;
+        if (_streak > _bestStreak) _bestStreak = _streak;
+        _xp += 10;
+      } else {
+        _streak = 0;
+        _missed[targetIdx] = (_missed[targetIdx] ?? 0) + 1;
+      }
+    });
+    if (ok) {
+      HapticFeedback.mediumImpact();
+      _confetti.play();
+    } else {
+      HapticFeedback.heavyImpact();
+      _shakeCtrl.forward(from: 0);
+    }
+  }
+
+  Future<void> _playNative() async {
+    if (!_ttsReady) return;
+    HapticFeedback.selectionClick();
+    await _tts.stop();
+    await _tts.speak(_target.kana);
+  }
+
+  Future<void> _next() async {
+    if (_roundIdx >= _totalRounds - 1) {
+      _sessionTimer.stop();
+      _xp += _sessionXpBonus;
+      _showEnd();
+      return;
+    }
+    _roundIdx += 1;
+    _newRound();
+  }
+
+  String _fmt(Duration d) {
+    final m = d.inMinutes.remainder(60).toString().padLeft(2, '0');
+    final s = d.inSeconds.remainder(60).toString().padLeft(2, '0');
+    return '$m:$s';
+  }
+
+  void _showEnd() {
+    final acc = _attempts == 0 ? 0 : ((_correct * 100) / _attempts).round();
+    showModalBottomSheet<void>(
+      context: context,
+      backgroundColor: Colors.transparent,
+      isScrollControlled: true,
+      builder: (_) => _WeekAwesomeResultSheet(
+        title: 'বলে দেখাও — সেশন শেষ',
+        scoreLabel: 'মোট XP: $_xp',
+        stats: [
+          'সঠিক: $_correct/$_totalRounds',
+          'নির্ভুলতা: $acc%',
+          'সেরা স্ট্রিক: $_bestStreak',
+          'সময়: ${_fmt(_sessionTimer.elapsed)}',
+        ],
+        missed: _missed.entries.map((e) {
+          final w = _weekdays[e.key];
+          return '${w.bn} — ${w.bnPronunciation}  ×${e.value}';
+        }).toList(),
+        onPlayAgain: () {
+          Navigator.of(context, rootNavigator: true).maybePop();
+          setState(() {
+            _roundIdx = 0;
+            _correct = 0;
+            _attempts = 0;
+            _xp = 0;
+            _streak = 0;
+            _bestStreak = 0;
+            _missed.clear();
+            _speakDeck = [];
+            _lastSpeakIdx = null;
+            _sessionTimer
+              ..reset()
+              ..start();
+          });
+          _newRound();
+        },
+      ),
+    );
+  }
+
+  @override
+  void dispose() {
+    _recordTimer?.cancel();
+    _confetti.dispose();
+    _pulseCtrl.dispose();
+    _shakeCtrl.dispose();
+    _stt.stop();
+    _tts.stop();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final progress = (_roundIdx + 1) / _totalRounds;
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(16, 0, 16, 16),
+      child: Stack(
+        clipBehavior: Clip.none,
+        children: [
+          _WeekConfettiOverlay(controller: _confetti, accent: _rose),
+          Column(
+            children: [
+              _WeekHeaderPanel(
+                color: _rose,
+                title: 'বলে দেখাও — বাংলা দেখে জাপানিতে বলুন',
+                progress: progress,
+                roundText: 'রাউন্ড ${_roundIdx + 1}/$_totalRounds',
+                xp: _xp,
+                streak: _streak,
+                timer: _fmt(_sessionTimer.elapsed),
+              ),
+              const SizedBox(height: 12),
+              AnimatedBuilder(
+                animation: _shakeCtrl,
+                builder: (context, child) {
+                  final t = _shakeCtrl.value;
+                  final dx = math.sin(t * math.pi * 6) * 10 * (1 - t);
+                  return Transform.translate(offset: Offset(dx, 0), child: child);
+                },
+                child: Container(
+                  width: double.infinity,
+                  padding: const EdgeInsets.all(18),
+                  decoration: BoxDecoration(
+                    color: const Color(0xFF1E293B),
+                    borderRadius: BorderRadius.circular(20),
+                    border: Border.all(color: _rose.withValues(alpha: 0.55), width: 2),
+                    boxShadow: [
+                      BoxShadow(
+                        color: _rose.withValues(alpha: 0.20),
+                        blurRadius: 22,
+                        offset: const Offset(0, 8),
+                      ),
+                    ],
+                  ),
+                  child: Column(
+                    children: [
+                      const Icon(Icons.calendar_month_rounded,
+                          color: _rose, size: 38),
+                      const SizedBox(height: 8),
+                      Text(
+                        _target.bn,
+                        style: const TextStyle(
+                          color: Colors.white,
+                          fontSize: 28,
+                          fontWeight: FontWeight.w900,
+                        ),
+                      ),
+                      const SizedBox(height: 4),
+                      Text(
+                        'জাপানিতে বলুন',
+                        style: TextStyle(
+                          color: Colors.white.withValues(alpha: 0.65),
+                          fontSize: 12,
+                          fontWeight: FontWeight.w700,
+                        ),
+                      ),
+                      if (_showHint || _evaluated) ...[
+                        const SizedBox(height: 10),
+                        Container(
+                          padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
+                          decoration: BoxDecoration(
+                            color: _rose.withValues(alpha: 0.15),
+                            borderRadius: BorderRadius.circular(99),
+                          ),
+                          child: Text(
+                            _target.bnPronunciation,
+                            style: const TextStyle(
+                              color: Color(0xFFFFE000),
+                              fontSize: 18,
+                              fontWeight: FontWeight.w900,
+                            ),
+                          ),
+                        ),
+                        const SizedBox(height: 4),
+                        Text(
+                          '${_target.jp}  •  ${_target.kana}',
+                          style: TextStyle(
+                            color: Colors.white.withValues(alpha: 0.78),
+                            fontSize: 13,
+                            fontWeight: FontWeight.w700,
+                          ),
+                        ),
+                      ],
+                    ],
+                  ),
+                ),
+              ),
+              const SizedBox(height: 14),
+              GestureDetector(
+                onTap: _listening ? _stopAndCheck : _startListening,
+                child: AnimatedBuilder(
+                  animation: _pulseCtrl,
+                  builder: (context, _) {
+                    final scale = _listening
+                        ? 1 + (_pulseCtrl.value * 0.08) + (_soundLevel.clamp(0, 10) / 60)
+                        : 1.0;
+                    return Transform.scale(
+                      scale: scale,
+                      child: Container(
+                        width: 76,
+                        height: 76,
+                        decoration: BoxDecoration(
+                          shape: BoxShape.circle,
+                          gradient: LinearGradient(
+                            colors: _listening
+                                ? const [Color(0xFFEF4444), Color(0xFFB91C1C)]
+                                : const [_rose, Color(0xFFBE123C)],
+                          ),
+                          boxShadow: [
+                            BoxShadow(
+                              color: (_listening ? const Color(0xFFEF4444) : _rose)
+                                  .withValues(alpha: 0.5),
+                              blurRadius: 22,
+                              spreadRadius: 2,
+                            ),
+                          ],
+                        ),
+                        child: Icon(
+                          _listening ? Icons.stop_rounded : Icons.mic_rounded,
+                          color: Colors.white,
+                          size: 36,
+                        ),
+                      ),
+                    );
+                  },
+                ),
+              ),
+              const SizedBox(height: 8),
+              Text(
+                _listening
+                    ? 'শুনছি… $_secondsLeft s'
+                    : (_evaluated ? 'আবার বলতে মাইক চাপুন' : 'মাইক চাপুন'),
+                style: const TextStyle(
+                  color: Colors.white,
+                  fontWeight: FontWeight.w900,
+                  fontSize: 13,
+                ),
+              ),
+              if (_heard.isNotEmpty) ...[
+                const SizedBox(height: 8),
+                Container(
+                  width: double.infinity,
+                  padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+                  decoration: BoxDecoration(
+                    color: Colors.white.withValues(alpha: 0.06),
+                    borderRadius: BorderRadius.circular(10),
+                    border: Border.all(color: Colors.white.withValues(alpha: 0.12)),
+                  ),
+                  child: Text(
+                    'শোনা গেল: $_heard',
+                    textAlign: TextAlign.center,
+                    style: const TextStyle(
+                      color: Color(0xFFFFE000),
+                      fontWeight: FontWeight.w900,
+                      fontSize: 13,
+                    ),
+                  ),
+                ),
+              ],
+              if (_evaluated) ...[
+                const SizedBox(height: 10),
+                Container(
+                  padding: const EdgeInsets.all(12),
+                  decoration: BoxDecoration(
+                    color: ((_lastScore ?? 0) >= 75
+                            ? const Color(0xFF10B981)
+                            : const Color(0xFFEF4444))
+                        .withValues(alpha: 0.15),
+                    borderRadius: BorderRadius.circular(14),
+                    border: Border.all(
+                      color: ((_lastScore ?? 0) >= 75
+                              ? const Color(0xFF10B981)
+                              : const Color(0xFFEF4444))
+                          .withValues(alpha: 0.5),
+                    ),
+                  ),
+                  child: Row(
+                    children: [
+                      Icon(
+                        (_lastScore ?? 0) >= 75
+                            ? Icons.check_circle_rounded
+                            : Icons.cancel_rounded,
+                        color: (_lastScore ?? 0) >= 75
+                            ? const Color(0xFF10B981)
+                            : const Color(0xFFEF4444),
+                      ),
+                      const SizedBox(width: 8),
+                      Expanded(
+                        child: Text(
+                          (_lastScore ?? 0) >= 92
+                              ? 'চমৎকার উচ্চারণ! (${_lastScore ?? 0}%)'
+                              : (_lastScore ?? 0) >= 75
+                                  ? 'ভালো হয়েছে! (${_lastScore ?? 0}%)'
+                                  : 'আরেকবার চেষ্টা করুন (${_lastScore ?? 0}%)',
+                          style: TextStyle(
+                            color: (_lastScore ?? 0) >= 75
+                                ? const Color(0xFF10B981)
+                                : const Color(0xFFEF4444),
+                            fontWeight: FontWeight.w900,
+                            fontSize: 13,
+                          ),
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+              ],
+              if (_error != null) ...[
+                const SizedBox(height: 6),
+                Text(
+                  _error!,
+                  style: const TextStyle(
+                    color: Color(0xFFEF4444),
+                    fontSize: 11,
+                    fontWeight: FontWeight.w700,
+                  ),
+                  textAlign: TextAlign.center,
+                ),
+              ],
+              const Spacer(),
+              Row(
+                children: [
+                  Expanded(
+                    child: OutlinedButton.icon(
+                      onPressed: _ttsReady ? _playNative : null,
+                      style: OutlinedButton.styleFrom(
+                        foregroundColor: Colors.white,
+                        side: BorderSide(color: Colors.white.withValues(alpha: 0.4)),
+                        padding: const EdgeInsets.symmetric(vertical: 12),
+                        shape: RoundedRectangleBorder(
+                            borderRadius: BorderRadius.circular(12)),
+                      ),
+                      icon: const Icon(Icons.volume_up_rounded),
+                      label: const Text('সঠিক শুনুন',
+                          style: TextStyle(fontWeight: FontWeight.w900)),
+                    ),
+                  ),
+                  const SizedBox(width: 10),
+                  Expanded(
+                    child: OutlinedButton.icon(
+                      onPressed: () => setState(() => _showHint = !_showHint),
+                      style: OutlinedButton.styleFrom(
+                        foregroundColor: _showHint ? _rose : Colors.white,
+                        side: BorderSide(
+                            color: _showHint
+                                ? _rose
+                                : Colors.white.withValues(alpha: 0.4)),
+                        padding: const EdgeInsets.symmetric(vertical: 12),
+                        shape: RoundedRectangleBorder(
+                            borderRadius: BorderRadius.circular(12)),
+                      ),
+                      icon: Icon(_showHint
+                          ? Icons.visibility_off_rounded
+                          : Icons.lightbulb_rounded),
+                      label: Text(_showHint ? 'হিন্ট লুকান' : 'হিন্ট দেখুন',
+                          style: const TextStyle(fontWeight: FontWeight.w900)),
+                    ),
+                  ),
+                  const SizedBox(width: 10),
+                  Expanded(
+                    child: ElevatedButton.icon(
+                      onPressed: _evaluated ? _next : null,
+                      style: ElevatedButton.styleFrom(
+                        backgroundColor: _rose,
+                        foregroundColor: Colors.white,
+                        padding: const EdgeInsets.symmetric(vertical: 12),
+                        shape: RoundedRectangleBorder(
+                            borderRadius: BorderRadius.circular(12)),
+                      ),
+                      icon: const Icon(Icons.arrow_forward_rounded),
+                      label: const Text('পরবর্তী',
+                          style: TextStyle(fontWeight: FontWeight.w900)),
+                    ),
+                  ),
+                ],
+              ),
+            ],
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+// ═════════════════════════════════════════════════════════════════════
+// ক্রম বলো — Sequential speaking: say all 7 days in order, evaluate per slot
+// ═════════════════════════════════════════════════════════════════════
+
+enum _WeekSlotStatus { pending, correct, wrong, missed }
+
+class _WeekSlotResult {
+  const _WeekSlotResult({required this.expected, required this.heardIdx, required this.status});
+  final _Weekday expected;
+  final int? heardIdx; // index into _weekdays
+  final _WeekSlotStatus status;
+}
+
+class _WeekSeqSpeakGame extends StatefulWidget {
+  const _WeekSeqSpeakGame({super.key});
+  @override
+  State<_WeekSeqSpeakGame> createState() => _WeekSeqSpeakGameState();
+}
+
+class _WeekSeqSpeakGameState extends State<_WeekSeqSpeakGame>
+    with TickerProviderStateMixin {
+  static const _amber = Color(0xFFF59E0B);
+  static const _maxSeconds = 20;
+
+  final _stt = SpeechToText();
+  final _tts = FlutterTts();
+  bool _sttReady = false;
+  bool _ttsReady = false;
+  String? _locale;
+  String? _error;
+  bool _listening = false;
+  String _heard = '';
+  double _soundLevel = 0;
+  int _secondsLeft = 0;
+  Timer? _recordTimer;
+
+  late List<_WeekSlotResult> _results;
+  List<int> _extras = const [];
+  bool _evaluated = false;
+
+  int _xp = 0;
+  int _attempts = 0;
+  int _bestCorrect = 0;
+  final Stopwatch _sessionTimer = Stopwatch();
+
+  late ConfettiController _confetti;
+  late AnimationController _pulseCtrl;
+
+  @override
+  void initState() {
+    super.initState();
+    _results = _weekdays
+        .map((w) => _WeekSlotResult(
+            expected: w, heardIdx: null, status: _WeekSlotStatus.pending))
+        .toList();
+    _confetti = ConfettiController(duration: const Duration(milliseconds: 900));
+    _pulseCtrl = AnimationController(
+        vsync: this, duration: const Duration(milliseconds: 1100))
+      ..repeat(reverse: true);
+    _sessionTimer.start();
+    _initTts();
+    _initStt();
+  }
+
+  @override
+  void dispose() {
+    _recordTimer?.cancel();
+    _confetti.dispose();
+    _pulseCtrl.dispose();
+    _stt.stop();
+    _tts.stop();
+    super.dispose();
+  }
+
+  Future<void> _initTts() async {
+    try {
+      await _tts.setLanguage('ja-JP');
+      await _tts.setSpeechRate(0.42);
+      if (mounted) setState(() => _ttsReady = true);
+    } catch (_) {}
+  }
+
+  Future<void> _initStt() async {
+    try {
+      final ok = await _stt.initialize(
+        onError: (e) {
+          if (!mounted) return;
+          setState(() => _error = e.errorMsg);
+        },
+        onStatus: (_) {},
+      );
+      if (!mounted) return;
+      if (!ok) {
+        setState(() => _sttReady = false);
+        return;
+      }
+      final locales = await _stt.locales();
+      final ja = locales.where((l) => l.localeId.toLowerCase().startsWith('ja'));
+      setState(() {
+        _locale = ja.isNotEmpty
+            ? ja.first.localeId
+            : (locales.isNotEmpty ? locales.first.localeId : null);
+        _sttReady = true;
+      });
+    } catch (e) {
+      if (!mounted) return;
+      setState(() {
+        _sttReady = false;
+        _error = '$e';
+      });
+    }
+  }
+
+  // ─── Match a token to a weekday index (0..6) ─────────────────────
+  static const _wordTable = <String, int>{
+    // Monday
+    'げつようび': 0, 'getsuyoubi': 0, 'getsuyobi': 0, '月曜日': 0, 'げつよう': 0, 'げつ': 0,
+    // Tuesday
+    'かようび': 1, 'kayoubi': 1, 'kayobi': 1, '火曜日': 1, 'かよう': 1, 'か': 1,
+    // Wednesday
+    'すいようび': 2, 'suiyoubi': 2, 'suiyobi': 2, '水曜日': 2, 'すいよう': 2, 'すい': 2,
+    // Thursday
+    'もくようび': 3, 'mokuyoubi': 3, 'mokuyobi': 3, '木曜日': 3, 'もくよう': 3, 'もく': 3,
+    // Friday
+    'きんようび': 4, 'kinyoubi': 4, 'kinyobi': 4, '金曜日': 4, 'きんよう': 4, 'きん': 4,
+    // Saturday
+    'どようび': 5, 'doyoubi': 5, 'doyobi': 5, '土曜日': 5, 'どよう': 5, 'ど': 5,
+    // Sunday
+    'にちようび': 6, 'nichiyoubi': 6, 'nichiyobi': 6, '日曜日': 6, 'にちよう': 6, 'にち': 6,
+  };
+
+  static String _normalize(String s) {
+    var out = s.toLowerCase();
+    final buf = StringBuffer();
+    for (final r in out.runes) {
+      if (r >= 0xFF10 && r <= 0xFF19) {
+        buf.writeCharCode(r - 0xFF10 + 0x30);
+        continue;
+      }
+      if (r == 0x30FC) continue;
+      const smallToBig = {
+        0x3041: 0x3042, 0x3043: 0x3044, 0x3045: 0x3046,
+        0x3047: 0x3048, 0x3049: 0x304A,
+        0x30A1: 0x30A2, 0x30A3: 0x30A4, 0x30A5: 0x30A6,
+        0x30A7: 0x30A8, 0x30A9: 0x30AA,
+      };
+      buf.writeCharCode(smallToBig[r] ?? r);
+    }
+    return buf.toString();
+  }
+
+  List<int> _parseHeard(String raw) {
+    final cleaned = _normalize(raw)
+        .replaceAll(RegExp(r'[、。,.!?・〜\-‐–—()\[\]「」]'), ' ');
+    final tokens = cleaned.split(RegExp(r'\s+')).where((s) => s.isNotEmpty);
+    final out = <int>[];
+    for (final t in tokens) {
+      final exact = _wordTable[t];
+      if (exact != null) {
+        out.add(exact);
+        continue;
+      }
+      // Greedy substring scan for concatenated speech.
+      int i = 0;
+      while (i < t.length) {
+        bool matched = false;
+        final maxLen = math.min(8, t.length - i);
+        for (int len = maxLen; len >= 1 && !matched; len--) {
+          final sub = t.substring(i, i + len);
+          final n = _wordTable[sub];
+          if (n != null) {
+            out.add(n);
+            i += len;
+            matched = true;
+          }
+        }
+        if (!matched) i++;
+      }
+    }
+    return out;
+  }
+
+  void _evaluate(List<int> heard) {
+    final entries = <_WeekSlotResult>[];
+    int correctCount = 0;
+    for (var i = 0; i < _weekdays.length; i++) {
+      if (i >= heard.length) {
+        entries.add(_WeekSlotResult(
+            expected: _weekdays[i],
+            heardIdx: null,
+            status: _WeekSlotStatus.missed));
+        continue;
+      }
+      final h = heard[i];
+      if (h == i) {
+        entries.add(_WeekSlotResult(
+            expected: _weekdays[i],
+            heardIdx: h,
+            status: _WeekSlotStatus.correct));
+        correctCount++;
+      } else {
+        entries.add(_WeekSlotResult(
+            expected: _weekdays[i],
+            heardIdx: h,
+            status: _WeekSlotStatus.wrong));
+      }
+    }
+    final extras = heard.length > _weekdays.length
+        ? heard.sublist(_weekdays.length)
+        : const <int>[];
+
+    _attempts += 1;
+    if (correctCount > _bestCorrect) _bestCorrect = correctCount;
+    // XP: +10 per correct slot, +50 bonus for perfect run.
+    final delta = correctCount * 10 + (correctCount == 7 ? 50 : 0);
+    _xp += delta;
+
+    setState(() {
+      _results = entries;
+      _extras = extras;
+      _evaluated = true;
+    });
+
+    if (correctCount == 7 && extras.isEmpty) {
+      HapticFeedback.heavyImpact();
+      _confetti.play();
+    } else if (correctCount >= 5) {
+      HapticFeedback.mediumImpact();
+    } else {
+      HapticFeedback.lightImpact();
+    }
+  }
+
+  Future<void> _startListening() async {
+    if (_listening) return;
+    HapticFeedback.mediumImpact();
+    setState(() {
+      _heard = '';
+      _error = null;
+      _evaluated = false;
+      _extras = const [];
+      _results = _weekdays
+          .map((w) => _WeekSlotResult(
+              expected: w, heardIdx: null, status: _WeekSlotStatus.pending))
+          .toList();
+      _secondsLeft = _maxSeconds;
+      _soundLevel = 0;
+    });
+    try {
+      if (!_sttReady) await _initStt();
+      if (!_sttReady) {
+        throw Exception('Speech recognition এই ডিভাইসে কাজ করছে না।');
+      }
+      await _stt.listen(
+        localeId: _locale,
+        listenMode: ListenMode.dictation,
+        partialResults: true,
+        cancelOnError: true,
+        listenFor: const Duration(seconds: _maxSeconds),
+        pauseFor: const Duration(seconds: 4),
+        onResult: (SpeechRecognitionResult r) {
+          if (!mounted) return;
+          setState(() => _heard = r.recognizedWords);
+        },
+        onSoundLevelChange: (level) {
+          if (!mounted) return;
+          setState(() => _soundLevel = level);
+        },
+      );
+      if (!mounted) return;
+      setState(() => _listening = true);
+      _recordTimer?.cancel();
+      _recordTimer = Timer.periodic(const Duration(seconds: 1), (_) async {
+        if (!mounted || !_listening) return;
+        if (_secondsLeft <= 1) {
+          await _stopAndEvaluate();
+          return;
+        }
+        setState(() => _secondsLeft -= 1);
+      });
+    } catch (e) {
+      if (!mounted) return;
+      _recordTimer?.cancel();
+      setState(() {
+        _listening = false;
+        _error = '$e';
+      });
+    }
+  }
+
+  Future<void> _stopAndEvaluate() async {
+    if (!_listening) return;
+    _recordTimer?.cancel();
+    HapticFeedback.selectionClick();
+    await _stt.stop();
+    if (!mounted) return;
+    setState(() {
+      _listening = false;
+      _secondsLeft = 0;
+      _soundLevel = 0;
+    });
+    _evaluate(_parseHeard(_heard));
+  }
+
+  Future<void> _speakAll() async {
+    if (!_ttsReady) return;
+    HapticFeedback.selectionClick();
+    await _tts.stop();
+    for (final w in _weekdays) {
+      if (!mounted) return;
+      await _tts.speak(w.kana);
+      await Future.delayed(const Duration(milliseconds: 320));
+    }
+  }
+
+  Future<void> _speakMistakes() async {
+    if (!_ttsReady) return;
+    HapticFeedback.selectionClick();
+    await _tts.stop();
+    final mistakes = _results.where((r) =>
+        r.status == _WeekSlotStatus.wrong || r.status == _WeekSlotStatus.missed);
+    for (final r in mistakes) {
+      if (!mounted) return;
+      await _tts.speak(r.expected.kana);
+      await Future.delayed(const Duration(milliseconds: 380));
+    }
+  }
+
+  String _fmt(Duration d) {
+    final m = d.inMinutes.remainder(60).toString().padLeft(2, '0');
+    final s = d.inSeconds.remainder(60).toString().padLeft(2, '0');
+    return '$m:$s';
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final correctCount =
+        _results.where((r) => r.status == _WeekSlotStatus.correct).length;
+    final wrongCount =
+        _results.where((r) => r.status == _WeekSlotStatus.wrong).length;
+    final missedCount =
+        _results.where((r) => r.status == _WeekSlotStatus.missed).length;
+    final accuracy =
+        _evaluated ? ((correctCount * 100) / _weekdays.length).round() : 0;
+
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(16, 0, 16, 16),
+      child: Stack(
+        clipBehavior: Clip.none,
+        children: [
+          _WeekConfettiOverlay(controller: _confetti, accent: _amber),
+          Column(
+            children: [
+              _WeekHeaderPanel(
+                color: _amber,
+                title: 'ক্রম বলো — সোম থেকে রবি একবারে বলুন',
+                progress: _evaluated ? correctCount / _weekdays.length : 0,
+                roundText: _evaluated
+                    ? 'সঠিক: $correctCount/${_weekdays.length}'
+                    : 'মাইক চাপুন',
+                xp: _xp,
+                streak: _bestCorrect,
+                timer: _listening ? '$_secondsLeft s' : _fmt(_sessionTimer.elapsed),
+              ),
+              const SizedBox(height: 12),
+              Container(
+                width: double.infinity,
+                padding: const EdgeInsets.fromLTRB(16, 14, 16, 16),
+                decoration: BoxDecoration(
+                  gradient: const LinearGradient(
+                    colors: [Color(0xFF1E293B), Color(0xFF111827)],
+                    begin: Alignment.topLeft,
+                    end: Alignment.bottomRight,
+                  ),
+                  borderRadius: BorderRadius.circular(20),
+                  border: Border.all(color: _amber.withValues(alpha: 0.55), width: 2),
+                  boxShadow: [
+                    BoxShadow(
+                      color: _amber.withValues(alpha: 0.18),
+                      blurRadius: 22,
+                      offset: const Offset(0, 8),
+                    ),
+                  ],
+                ),
+                child: Column(
+                  children: [
+                    if (!_listening && !_evaluated)
+                      Text(
+                        'গেৎসুওবি → কায়োবি → … → নিচিয়োবি একবারে বলুন',
+                        textAlign: TextAlign.center,
+                        style: TextStyle(
+                          color: Colors.white.withValues(alpha: 0.78),
+                          fontSize: 12,
+                          fontWeight: FontWeight.w700,
+                        ),
+                      ),
+                    const SizedBox(height: 8),
+                    GestureDetector(
+                      onTap: _listening ? _stopAndEvaluate : _startListening,
+                      child: AnimatedBuilder(
+                        animation: _pulseCtrl,
+                        builder: (context, _) {
+                          final scale = _listening
+                              ? 1 + (_pulseCtrl.value * 0.08) + (_soundLevel.clamp(0, 10) / 60)
+                              : 1.0;
+                          return Transform.scale(
+                            scale: scale,
+                            child: Container(
+                              width: 78,
+                              height: 78,
+                              decoration: BoxDecoration(
+                                shape: BoxShape.circle,
+                                gradient: LinearGradient(
+                                  colors: _listening
+                                      ? const [Color(0xFFEF4444), Color(0xFFB91C1C)]
+                                      : const [_amber, Color(0xFFB45309)],
+                                ),
+                                boxShadow: [
+                                  BoxShadow(
+                                    color: (_listening ? const Color(0xFFEF4444) : _amber)
+                                        .withValues(alpha: 0.5),
+                                    blurRadius: 22,
+                                    spreadRadius: 2,
+                                  ),
+                                ],
+                              ),
+                              child: Icon(
+                                _listening ? Icons.stop_rounded : Icons.mic_rounded,
+                                color: Colors.white,
+                                size: 38,
+                              ),
+                            ),
+                          );
+                        },
+                      ),
+                    ),
+                    const SizedBox(height: 8),
+                    Text(
+                      _listening ? 'শুনছি — বলতে থাকুন…' : (_evaluated ? 'আবার চেষ্টা' : 'মাইক চাপুন'),
+                      style: const TextStyle(
+                        color: Colors.white,
+                        fontWeight: FontWeight.w900,
+                        fontSize: 13,
+                      ),
+                    ),
+                    if (_heard.isNotEmpty) ...[
+                      const SizedBox(height: 8),
+                      Container(
+                        width: double.infinity,
+                        padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 6),
+                        decoration: BoxDecoration(
+                          color: Colors.white.withValues(alpha: 0.06),
+                          borderRadius: BorderRadius.circular(10),
+                          border: Border.all(color: Colors.white.withValues(alpha: 0.12)),
+                        ),
+                        child: Text(
+                          _heard,
+                          textAlign: TextAlign.center,
+                          style: const TextStyle(
+                            color: Color(0xFFFFE000),
+                            fontWeight: FontWeight.w900,
+                            fontSize: 13,
+                          ),
+                        ),
+                      ),
+                    ],
+                    if (_error != null) ...[
+                      const SizedBox(height: 6),
+                      Text(
+                        _error!,
+                        style: const TextStyle(
+                          color: Color(0xFFEF4444),
+                          fontSize: 11,
+                          fontWeight: FontWeight.w700,
+                        ),
+                        textAlign: TextAlign.center,
+                      ),
+                    ],
+                  ],
+                ),
+              ),
+              const SizedBox(height: 10),
+              if (_evaluated)
+                Row(
+                  children: [
+                    _summaryChip(
+                        label: 'সঠিক',
+                        value: '$correctCount',
+                        color: const Color(0xFF10B981)),
+                    const SizedBox(width: 8),
+                    _summaryChip(
+                        label: 'ভুল',
+                        value: '$wrongCount',
+                        color: const Color(0xFFEF4444)),
+                    const SizedBox(width: 8),
+                    _summaryChip(
+                        label: 'বাদ',
+                        value: '$missedCount',
+                        color: const Color(0xFFF59E0B)),
+                    if (_extras.isNotEmpty) ...[
+                      const SizedBox(width: 8),
+                      _summaryChip(
+                          label: 'অতিরিক্ত',
+                          value: '${_extras.length}',
+                          color: const Color(0xFF8B5CF6)),
+                    ],
+                  ],
+                ),
+              if (_evaluated)
+                Padding(
+                  padding: const EdgeInsets.only(top: 4),
+                  child: Align(
+                    alignment: Alignment.centerRight,
+                    child: Text(
+                      'নির্ভুলতা: $accuracy%',
+                      style: TextStyle(
+                        color: Colors.white.withValues(alpha: 0.75),
+                        fontSize: 11,
+                        fontWeight: FontWeight.w700,
+                      ),
+                    ),
+                  ),
+                ),
+              if (_evaluated) const SizedBox(height: 8),
+              Expanded(child: _buildSlotsList()),
+              if (_evaluated) ...[
+                const SizedBox(height: 8),
+                Row(
+                  children: [
+                    Expanded(
+                      child: OutlinedButton.icon(
+                        onPressed: _ttsReady ? _speakAll : null,
+                        style: OutlinedButton.styleFrom(
+                          foregroundColor: Colors.white,
+                          side: BorderSide(color: Colors.white.withValues(alpha: 0.4)),
+                          padding: const EdgeInsets.symmetric(vertical: 12),
+                          shape: RoundedRectangleBorder(
+                              borderRadius: BorderRadius.circular(12)),
+                        ),
+                        icon: const Icon(Icons.volume_up_rounded),
+                        label: const Text('সব শুনুন',
+                            style: TextStyle(fontWeight: FontWeight.w900)),
+                      ),
+                    ),
+                    const SizedBox(width: 10),
+                    Expanded(
+                      child: ElevatedButton.icon(
+                        onPressed: _ttsReady ? _speakMistakes : null,
+                        style: ElevatedButton.styleFrom(
+                          backgroundColor: _amber,
+                          foregroundColor: Colors.white,
+                          padding: const EdgeInsets.symmetric(vertical: 12),
+                          shape: RoundedRectangleBorder(
+                              borderRadius: BorderRadius.circular(12)),
+                        ),
+                        icon: const Icon(Icons.school_rounded),
+                        label: const Text('ভুলগুলি শুনুন',
+                            style: TextStyle(fontWeight: FontWeight.w900)),
+                      ),
+                    ),
+                  ],
+                ),
+              ],
+            ],
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _summaryChip({required String label, required String value, required Color color}) {
+    return Expanded(
+      child: Container(
+        padding: const EdgeInsets.symmetric(vertical: 8),
+        decoration: BoxDecoration(
+          color: color.withValues(alpha: 0.15),
+          borderRadius: BorderRadius.circular(12),
+          border: Border.all(color: color.withValues(alpha: 0.5)),
+        ),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Text(value,
+                style: TextStyle(
+                    color: color,
+                    fontSize: 17,
+                    fontWeight: FontWeight.w900)),
+            Text(label,
+                style: TextStyle(
+                    color: color, fontSize: 10, fontWeight: FontWeight.w700)),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildSlotsList() {
+    return ListView.builder(
+      physics: const BouncingScrollPhysics(),
+      itemCount: _results.length,
+      itemBuilder: (_, i) {
+        final r = _results[i];
+        Color color;
+        IconData icon;
+        String detail;
+        switch (r.status) {
+          case _WeekSlotStatus.correct:
+            color = const Color(0xFF10B981);
+            icon = Icons.check_circle_rounded;
+            detail = 'বলেছেন ✓';
+            break;
+          case _WeekSlotStatus.wrong:
+            final heard = _weekdays[r.heardIdx!];
+            color = const Color(0xFFEF4444);
+            icon = Icons.cancel_rounded;
+            detail = 'বলেছেন: ${heard.bnPronunciation}';
+            break;
+          case _WeekSlotStatus.missed:
+            color = const Color(0xFFF59E0B);
+            icon = Icons.remove_circle_outline_rounded;
+            detail = 'বাদ পড়েছে';
+            break;
+          case _WeekSlotStatus.pending:
+            color = Colors.white.withValues(alpha: 0.3);
+            icon = Icons.radio_button_unchecked_rounded;
+            detail = 'অপেক্ষমাণ';
+            break;
+        }
+        return Padding(
+          padding: const EdgeInsets.only(bottom: 8),
+          child: Container(
+            padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 10),
+            decoration: BoxDecoration(
+              color: color.withValues(alpha: 0.10),
+              borderRadius: BorderRadius.circular(12),
+              border: Border.all(color: color.withValues(alpha: 0.55)),
+            ),
+            child: Row(
+              children: [
+                Container(
+                  width: 34,
+                  height: 34,
+                  alignment: Alignment.center,
+                  decoration: BoxDecoration(
+                    color: color.withValues(alpha: 0.20),
+                    borderRadius: BorderRadius.circular(10),
+                  ),
+                  child: Text(
+                    '${i + 1}',
+                    style: TextStyle(
+                      color: color,
+                      fontSize: 15,
+                      fontWeight: FontWeight.w900,
+                    ),
+                  ),
+                ),
+                const SizedBox(width: 10),
+                Expanded(
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Text(
+                        '${r.expected.bn} — ${r.expected.bnPronunciation}',
+                        style: const TextStyle(
+                          color: Colors.white,
+                          fontSize: 14,
+                          fontWeight: FontWeight.w900,
+                        ),
+                      ),
+                      Text(
+                        detail,
+                        style: TextStyle(
+                          color: color,
+                          fontSize: 11,
+                          fontWeight: FontWeight.w700,
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+                Icon(icon, color: color, size: 22),
+              ],
+            ),
+          ),
+        );
+      },
+    );
+  }
+}
+
+// ═════════════════════════════════════════════════════════════════════
+// Shared widgets used by the new games
+// ═════════════════════════════════════════════════════════════════════
+
+class _WeekConfettiOverlay extends StatelessWidget {
+  const _WeekConfettiOverlay({required this.controller, required this.accent});
+  final ConfettiController controller;
+  final Color accent;
+
+  @override
+  Widget build(BuildContext context) {
+    return Align(
+      alignment: Alignment.topCenter,
+      child: IgnorePointer(
+        child: SizedBox(
+          height: 140,
+          width: double.infinity,
+          child: ConfettiWidget(
+            confettiController: controller,
+            blastDirectionality: BlastDirectionality.explosive,
+            maxBlastForce: 16,
+            minBlastForce: 6,
+            emissionFrequency: 0.08,
+            numberOfParticles: 14,
+            gravity: 0.22,
+            shouldLoop: false,
+            colors: [
+              const Color(0xFFFFE000),
+              const Color(0xFF10B981),
+              accent,
+              const Color(0xFF3B82F6),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _WeekHeaderPanel extends StatelessWidget {
+  const _WeekHeaderPanel({
+    required this.color,
+    required this.title,
+    required this.progress,
+    required this.roundText,
+    required this.xp,
+    required this.streak,
+    required this.timer,
+  });
+
+  final Color color;
+  final String title;
+  final double progress;
+  final String roundText;
+  final int xp;
+  final int streak;
+  final String timer;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.all(14),
+      decoration: BoxDecoration(
+        color: const Color(0xFF1E293B),
+        borderRadius: BorderRadius.circular(16),
+        border: Border.all(color: color.withValues(alpha: 0.45)),
+        boxShadow: [
+          BoxShadow(
+            color: color.withValues(alpha: 0.12),
+            blurRadius: 18,
+            offset: const Offset(0, 8),
+          ),
+        ],
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          Row(
+            children: [
+              Expanded(
+                child: Text(title,
+                    style: const TextStyle(
+                        color: Colors.white,
+                        fontWeight: FontWeight.w900,
+                        fontSize: 13)),
+              ),
+              Text(timer,
+                  style: TextStyle(
+                      color: Colors.white.withValues(alpha: 0.85),
+                      fontWeight: FontWeight.w900)),
+            ],
+          ),
+          const SizedBox(height: 10),
+          LinearProgressIndicator(
+            minHeight: 8,
+            borderRadius: BorderRadius.circular(99),
+            value: progress.clamp(0, 1),
+            backgroundColor: Colors.white.withValues(alpha: 0.12),
+            valueColor: AlwaysStoppedAnimation(color),
+          ),
+          const SizedBox(height: 8),
+          Row(
+            children: [
+              Text(roundText,
+                  style: TextStyle(
+                      color: Colors.white.withValues(alpha: 0.82),
+                      fontWeight: FontWeight.w800)),
+              const Spacer(),
+              Text('XP: $xp',
+                  style: const TextStyle(
+                      color: Color(0xFFFFE000),
+                      fontWeight: FontWeight.w900)),
+              const SizedBox(width: 10),
+              Text('স্ট্রিক: $streak',
+                  style: TextStyle(
+                      color: Colors.white.withValues(alpha: 0.82),
+                      fontWeight: FontWeight.w800)),
+            ],
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _WeekOptionTile extends StatelessWidget {
+  const _WeekOptionTile({
+    required this.label,
+    required this.sublabel,
+    required this.picked,
+    required this.isCorrect,
+    required this.revealed,
+    required this.onTap,
+  });
+
+  final String label;
+  final String sublabel;
+  final bool picked;
+  final bool isCorrect;
+  final bool revealed;
+  final VoidCallback? onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    Color border;
+    Color bg;
+    Color textColor = Colors.white;
+    if (!revealed) {
+      border = Colors.white.withValues(alpha: 0.18);
+      bg = Colors.white.withValues(alpha: 0.07);
+    } else if (isCorrect) {
+      border = const Color(0xFF10B981);
+      bg = const Color(0xFF10B981).withValues(alpha: 0.22);
+      textColor = const Color(0xFF10B981);
+    } else if (picked) {
+      border = const Color(0xFFEF4444);
+      bg = const Color(0xFFEF4444).withValues(alpha: 0.18);
+      textColor = const Color(0xFFEF4444);
+    } else {
+      border = Colors.white.withValues(alpha: 0.10);
+      bg = Colors.white.withValues(alpha: 0.04);
+    }
+    return Expanded(
+      child: Material(
+        color: Colors.transparent,
+        child: InkWell(
+          borderRadius: BorderRadius.circular(14),
+          onTap: onTap,
+          child: Ink(
+            decoration: BoxDecoration(
+              color: bg,
+              borderRadius: BorderRadius.circular(14),
+              border: Border.all(
+                color: border,
+                width: (picked || (isCorrect && revealed)) ? 2.4 : 1.2,
+              ),
+            ),
+            padding: const EdgeInsets.symmetric(horizontal: 12),
+            child: Row(
+              children: [
+                Expanded(
+                  child: Column(
+                    mainAxisAlignment: MainAxisAlignment.center,
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Text(
+                        label,
+                        style: TextStyle(
+                          color: textColor,
+                          fontSize: 16,
+                          fontWeight: FontWeight.w900,
+                        ),
+                      ),
+                      if (sublabel.isNotEmpty)
+                        Text(
+                          sublabel,
+                          style: TextStyle(
+                            color: textColor.withValues(alpha: 0.65),
+                            fontSize: 11,
+                            fontWeight: FontWeight.w700,
+                          ),
+                        ),
+                    ],
+                  ),
+                ),
+                if (revealed && isCorrect)
+                  const Icon(Icons.check_circle_rounded,
+                      color: Color(0xFF10B981), size: 22),
+                if (revealed && picked && !isCorrect)
+                  const Icon(Icons.cancel_rounded,
+                      color: Color(0xFFEF4444), size: 22),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _WeekCorrectBanner extends StatelessWidget {
+  const _WeekCorrectBanner({
+    required this.visible,
+    required this.streak,
+    required this.text,
+  });
+
+  final bool visible;
+  final int streak;
+  final String text;
+
+  @override
+  Widget build(BuildContext context) {
+    return Positioned(
+      left: 0,
+      right: 0,
+      bottom: 0,
+      child: AnimatedSlide(
+        duration: const Duration(milliseconds: 360),
+        curve: Curves.easeOutCubic,
+        offset: visible ? Offset.zero : const Offset(0, 1.2),
+        child: AnimatedOpacity(
+          duration: const Duration(milliseconds: 220),
+          opacity: visible ? 1 : 0,
+          child: IgnorePointer(
+            ignoring: !visible,
+            child: Container(
+              margin: const EdgeInsets.only(bottom: 6),
+              padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 14),
+              decoration: BoxDecoration(
+                color: const Color(0xFF10B981),
+                borderRadius: BorderRadius.circular(16),
+                boxShadow: [
+                  BoxShadow(
+                    color: Colors.black.withValues(alpha: 0.35),
+                    blurRadius: 18,
+                    offset: const Offset(0, 8),
+                  ),
+                ],
+              ),
+              child: Column(
+                mainAxisSize: MainAxisSize.min,
+                crossAxisAlignment: CrossAxisAlignment.stretch,
+                children: [
+                  Row(
+                    children: [
+                      const Icon(Icons.thumb_up_alt_rounded,
+                          color: Colors.white, size: 26),
+                      const SizedBox(width: 10),
+                      const Text('সঠিক!',
+                          style: TextStyle(
+                              color: Colors.white,
+                              fontWeight: FontWeight.w900,
+                              fontSize: 22)),
+                      const Spacer(),
+                      Row(
+                        children: List.generate(
+                          5,
+                          (i) => Padding(
+                            padding: const EdgeInsets.only(left: 2),
+                            child: Icon(
+                              Icons.star_rounded,
+                              color: i < math.min(5, streak)
+                                  ? const Color(0xFFFFE000)
+                                  : Colors.white.withValues(alpha: 0.22),
+                              size: 22,
+                            ),
+                          ),
+                        ),
+                      ),
+                    ],
+                  ),
+                  const SizedBox(height: 6),
+                  Text(
+                    text,
+                    textAlign: TextAlign.center,
+                    style: const TextStyle(
+                      color: Colors.white,
+                      fontWeight: FontWeight.w800,
+                      fontSize: 15,
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _WeekStatChip extends StatelessWidget {
+  const _WeekStatChip({required this.label, required this.value});
+  final String label;
+  final String value;
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+      decoration: BoxDecoration(
+        color: Colors.white.withValues(alpha: 0.08),
+        borderRadius: BorderRadius.circular(8),
+        border: Border.all(color: Colors.white.withValues(alpha: 0.14)),
+      ),
+      child: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Text(label,
+              style: TextStyle(
+                  color: Colors.white.withValues(alpha: 0.7),
+                  fontSize: 10,
+                  fontWeight: FontWeight.w800)),
+          const SizedBox(width: 4),
+          Text(value,
+              style: const TextStyle(
+                  color: Color(0xFFFFE000),
+                  fontWeight: FontWeight.w900,
+                  fontSize: 12)),
+        ],
+      ),
+    );
+  }
+}
+
+class _WeekFlipFace extends StatelessWidget {
+  const _WeekFlipFace({super.key, required this.item, required this.turns});
+  final _Weekday item;
+  final double turns;
+
+  @override
+  Widget build(BuildContext context) {
+    return TweenAnimationBuilder<double>(
+      tween: Tween<double>(begin: 0, end: turns),
+      duration: const Duration(milliseconds: 420),
+      curve: Curves.easeInOutCubic,
+      builder: (context, value, _) {
+        final v = value % (2 * math.pi);
+        final showFront = v <= math.pi / 2 || v >= (3 * math.pi) / 2;
+        final angle = showFront ? v : v + math.pi;
+
+        final front = Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            Text(item.jp,
+                style: const TextStyle(
+                    color: Colors.white,
+                    fontSize: 56,
+                    fontWeight: FontWeight.w900)),
+            const SizedBox(height: 10),
+            Text(item.kana,
+                style: TextStyle(
+                    color: Colors.white.withValues(alpha: 0.82),
+                    fontSize: 24,
+                    fontWeight: FontWeight.w700)),
+            const SizedBox(height: 6),
+            Text('উচ্চারণ: ${item.bnPronunciation}',
+                style: TextStyle(
+                    color: Colors.white.withValues(alpha: 0.85),
+                    fontWeight: FontWeight.w700)),
+          ],
+        );
+
+        final back = Text(
+          item.bn,
+          style: const TextStyle(
+              color: Color(0xFFFFE000),
+              fontSize: 50,
+              fontWeight: FontWeight.w900),
+          textAlign: TextAlign.center,
+        );
+
+        return Transform(
+          alignment: Alignment.center,
+          transform: Matrix4.identity()
+            ..setEntry(3, 2, 0.0012)
+            ..rotateY(angle),
+          child: showFront ? front : back,
+        );
+      },
+    );
+  }
+}
+
+BoxDecoration _card({double radius = 16}) => BoxDecoration(
+      color: const Color(0xFF1E293B),
+      borderRadius: BorderRadius.circular(radius),
+      border: Border.all(color: Colors.white.withValues(alpha: 0.10)),
+    );
+
+void _showWeekAwesomeResult({
+  required BuildContext context,
+  required String title,
+  required String scoreLabel,
+  required List<String> stats,
+  required List<MapEntry<String, int>> missed,
+  required VoidCallback onPlayAgain,
+}) {
+  final missedLines = <String>[];
+  for (final e in missed.take(6)) {
+    final d = _weekdays.firstWhere((x) => x.jp == e.key);
+    missedLines.add('${d.jp} (${d.bnPronunciation}) → ${d.bn}  ×${e.value}');
+  }
+  showModalBottomSheet<void>(
+    context: context,
+    backgroundColor: Colors.transparent,
+    isScrollControlled: true,
+    builder: (_) => _WeekAwesomeResultSheet(
+      title: title,
+      scoreLabel: scoreLabel,
+      stats: stats,
+      missed: missedLines,
+      onPlayAgain: onPlayAgain,
+    ),
+  );
+}
+
+class _WeekAwesomeResultSheet extends StatelessWidget {
+  const _WeekAwesomeResultSheet({
+    required this.title,
+    required this.scoreLabel,
+    required this.stats,
+    required this.missed,
+    required this.onPlayAgain,
+  });
+
+  final String title;
+  final String scoreLabel;
+  final List<String> stats;
+  final List<String> missed;
+  final VoidCallback onPlayAgain;
+
+  @override
+  Widget build(BuildContext context) {
+    return SafeArea(
+      child: Container(
+        margin: const EdgeInsets.fromLTRB(16, 0, 16, 16),
+        padding: const EdgeInsets.all(16),
+        decoration: BoxDecoration(
+          color: const Color(0xFF0B1326),
+          borderRadius: BorderRadius.circular(22),
+          border: Border.all(color: const Color(0xFFFFE000).withValues(alpha: 0.18)),
+          boxShadow: [
+            BoxShadow(
+              color: Colors.black.withValues(alpha: 0.35),
+              blurRadius: 22,
+              offset: const Offset(0, 12),
+            )
+          ],
+        ),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            Row(
+              children: [
+                const Icon(Icons.emoji_events_rounded, color: Color(0xFFFFE000)),
+                const SizedBox(width: 10),
+                Expanded(
+                  child: Text(title,
+                      style: const TextStyle(color: Colors.white, fontWeight: FontWeight.w900, fontSize: 16)),
+                ),
+                IconButton(
+                  onPressed: () => Navigator.pop(context),
+                  icon: const Icon(Icons.close_rounded, color: Colors.white),
+                ),
+              ],
+            ),
+            const SizedBox(height: 6),
+            Container(
+              padding: const EdgeInsets.all(14),
+              decoration: BoxDecoration(
+                color: Colors.white.withValues(alpha: 0.06),
+                borderRadius: BorderRadius.circular(16),
+                border: Border.all(color: Colors.white.withValues(alpha: 0.10)),
+              ),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(scoreLabel,
+                      style: const TextStyle(color: Color(0xFFFFE000), fontWeight: FontWeight.w900, fontSize: 22)),
+                  const SizedBox(height: 10),
+                  Wrap(
+                    spacing: 8,
+                    runSpacing: 8,
+                    children: [
+                      for (final s in stats)
+                        Container(
+                          padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 6),
+                          decoration: BoxDecoration(
+                            color: const Color(0xFF1E293B),
+                            borderRadius: BorderRadius.circular(999),
+                            border: Border.all(color: Colors.white.withValues(alpha: 0.10)),
+                          ),
+                          child: Text(s,
+                              style: TextStyle(
+                                  color: Colors.white.withValues(alpha: 0.92),
+                                  fontWeight: FontWeight.w800,
+                                  fontSize: 12)),
+                        ),
+                    ],
+                  ),
+                ],
+              ),
+            ),
+            if (missed.isNotEmpty) ...[
+              const SizedBox(height: 12),
+              const Text('যেগুলো মিস হয়েছে',
+                  style: TextStyle(color: Colors.white, fontWeight: FontWeight.w900)),
+              const SizedBox(height: 8),
+              for (final m in missed)
+                Padding(
+                  padding: const EdgeInsets.only(bottom: 8),
+                  child: Container(
+                    padding: const EdgeInsets.all(12),
+                    decoration: BoxDecoration(
+                      color: Colors.white.withValues(alpha: 0.05),
+                      borderRadius: BorderRadius.circular(14),
+                      border: Border.all(color: Colors.white.withValues(alpha: 0.10)),
+                    ),
+                    child: Text(m,
+                        style: TextStyle(color: Colors.white.withValues(alpha: 0.92), fontWeight: FontWeight.w800)),
+                  ),
+                ),
+            ],
+            const SizedBox(height: 10),
+            ElevatedButton.icon(
+              onPressed: () {
+                Navigator.pop(context);
+                onPlayAgain();
+              },
+              style: ElevatedButton.styleFrom(
+                backgroundColor: const Color(0xFFFFE000),
+                foregroundColor: const Color(0xFF1E293B),
+                padding: const EdgeInsets.symmetric(vertical: 12),
+                shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(14)),
+              ),
+              icon: const Icon(Icons.refresh_rounded),
+              label: const Text('আবার খেলি', style: TextStyle(fontWeight: FontWeight.w900)),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- New **অনুশীলন** card on the JLC course list expands to reveal three practice lessons (পাঠ ১/২/৩), each opening a full lesson screen.
- Each lesson adds new listening / reading / speaking / sequence-speaking games on top of the existing flashcard / quiz / match / rush tabs.
- All prompts and options use Bengali pronunciations (e.g. ওহাইও গোজাইমাস, গেৎসুওবি) instead of English romaji.
- Speaking games use `ja-JP` STT with fuzzy matching that normalizes fullwidth digits, long-vowel marks, and small kana. Sequence-speak games (১-১০ বলো / ক্রম বলো) evaluate each position as correct / wrong / missed / extra.
- XP system simplified across all games: **+10 per correct answer, +50 session bonus, no penalty for wrong** (streak still resets). Pools draw without replacement so prompts don't repeat within a session.

## Test plan
- [ ] Open the JLC program — N5/N4 cards visible, plus the new অনুশীলন card at the bottom showing "৩টি পাঠ"
- [ ] Tap অনুশীলন — expands to show all three pathways (1️⃣ হিরো নাম্বার ১, 2️⃣ হাই-হ্যালো, 3️⃣ শুক্র-শনি বাকিটা জানি)
- [ ] Open পাঠ ১ — verify all 7 tabs work: শুনে ট্যাপ, পড়া মাস্টার, সাজাও, ১-১০ বলো, বলতে পারো, ম্যাচ মাস্টার, স্পিড বস
- [ ] Open পাঠ ২ — verify all 7 tabs: শুনে বলো, পড়ে বলো, বলে দেখাও, ফ্ল্যাশকার্ড, কুইজ রান, ফ্রেজ ম্যাচ, রাশ বস (incl. office "Ohayo gozaimasu" trick questions in পড়ে বলো)
- [ ] Open পাঠ ৩ — verify all 8 tabs: শুনে বলো, পড়ে বলো, বলে দেখাও, ক্রম বলো, ফ্ল্যাশকার্ড, কুইজ রান, ডে ম্যাচ, নেক্সট ডে (incl. Heijitsu / Shumatsu concept questions in পড়ে বলো)
- [ ] Speaking games: tap mic, say a word/sequence in Japanese — feedback shows score and per-slot results for sequence games
- [ ] Finish a session of any MCQ game — verify XP totals make sense (correct count × 10 + 50 bonus)
- [ ] Replay a session — verify no prompts repeat in the first pass through the pool