### PR TITLE
Add GitHub Actions workflow to build release APKs

### DIFF
--- a/.github/workflows/build-apk.yml
+++ b/.github/workflows/build-apk.yml
@@ -1,0 +1,67 @@
+name: Build Android APK
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+  release:
+    types: [created]
+
+jobs:
+  build:
+    name: Build APK
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '17'
+
+      - name: Set up Flutter
+        uses: subosito/flutter-action@v2
+        with:
+          channel: stable
+          cache: true
+
+      - name: Show Flutter version
+        run: flutter --version
+
+      - name: Install dependencies
+        run: flutter pub get
+
+      - name: Build per-ABI release APKs
+        run: flutter build apk --release --split-per-abi
+
+      - name: Build universal release APK
+        run: flutter build apk --release
+
+      - name: Upload per-ABI APKs
+        uses: actions/upload-artifact@v4
+        with:
+          name: ez-trainz-apks-${{ github.sha }}
+          path: build/app/outputs/flutter-apk/app-*-release.apk
+          if-no-files-found: error
+          retention-days: 30
+
+      - name: Upload universal APK
+        uses: actions/upload-artifact@v4
+        with:
+          name: ez-trainz-universal-${{ github.sha }}
+          path: build/app/outputs/flutter-apk/app-release.apk
+          if-no-files-found: error
+          retention-days: 30
+
+      - name: Attach APKs to release
+        if: github.event_name == 'release'
+        uses: softprops/action-gh-release@v2
+        with:
+          files: |
+            build/app/outputs/flutter-apk/app-release.apk
+            build/app/outputs/flutter-apk/app-arm64-v8a-release.apk
+            build/app/outputs/flutter-apk/app-armeabi-v7a-release.apk
+            build/app/outputs/flutter-apk/app-x86_64-release.apk


### PR DESCRIPTION
## Summary
- New workflow at `.github/workflows/build-apk.yml` that builds release APKs in the cloud, so you never need a local Flutter toolchain to get an installable APK.
- Triggers: every push to `main`, manual run from the Actions tab (`workflow_dispatch`), and on GitHub release creation.
- Produces two artifacts on every run:
  - **Per-ABI APKs** (`arm64-v8a`, `armeabi-v7a`, `x86_64`) — smaller, one per architecture
  - **Universal APK** — single fat APK that installs on any device
- When triggered by a release event, the APKs are also attached as downloadable assets on the release page.

## How to get an APK after this lands
1. Go to **Actions → Build Android APK** in the repo
2. Pick a workflow run (or trigger one manually with **Run workflow**)
3. Scroll to **Artifacts** and download `ez-trainz-universal-…` for the easy install, or `ez-trainz-apks-…` for the smaller per-ABI variants

## Test plan
- [ ] After merge, confirm the workflow auto-triggers on the merge commit
- [ ] Build succeeds end-to-end on ubuntu-latest with Flutter stable + JDK 17
- [ ] Both artifact zips appear on the run page and contain the expected `.apk` files
- [ ] Download the universal APK, install on an Android device, confirm the app launches and অনুশীলন lessons work