### PR TITLE
Render hiragana strokes with variable-width brush effect

### DIFF
--- a/lib/screens/hiragana_draw_game_screen.dart
+++ b/lib/screens/hiragana_draw_game_screen.dart
@@ -875,7 +875,7 @@ class _CharPainter extends CustomPainter {
   final double completeProgress;
   final bool showError;
 
-  static const _strokeWidth = 12.0;
+  static const _strokeWidth = 15.0;
 
   @override
   void paint(Canvas canvas, Size size) {
@@ -886,20 +886,20 @@ class _CharPainter extends CustomPainter {
     // Shadow template (faded full character) — only on tracing mode.
     if (showShadow) {
       for (int i = strokeIdx; i < character.strokes.length; i++) {
-        _drawIdealStroke(canvas, character.strokes[i], s,
-            color: Colors.white.withValues(alpha: 0.14),
-            strokeWidth: _strokeWidth);
+        _drawCalligraphicStroke(canvas, character.strokes[i], s,
+            color: Colors.white.withValues(alpha: 0.16),
+            baseWidth: _strokeWidth);
       }
     }
 
-    // Completed strokes — snapped to ideal path for crisp look.
+    // Completed strokes — rendered with a brush-like variable width.
     for (int i = 0; i < strokeIdx; i++) {
       final color = completed
           ? Color.lerp(Colors.white, const Color(0xFF10B981),
               completeProgress.clamp(0.0, 1.0))!
           : Colors.white;
-      _drawIdealStroke(canvas, character.strokes[i], s,
-          color: color, strokeWidth: _strokeWidth);
+      _drawCalligraphicStroke(canvas, character.strokes[i], s,
+          color: color, baseWidth: _strokeWidth);
     }
 
     // User's in-progress path.
@@ -1016,15 +1016,55 @@ class _CharPainter extends CustomPainter {
     }
   }
 
-  void _drawIdealStroke(Canvas canvas, _Stroke stroke, double s,
-      {required Color color, required double strokeWidth}) {
+  // Variable-width "brush" stroke: stamps filled circles along the path with
+  // radius driven by [_calligraphicWidthProfile] to mimic the natural
+  // pen-down → body → harai (taper) rhythm of real hiragana strokes.
+  void _drawCalligraphicStroke(
+    Canvas canvas,
+    _Stroke stroke,
+    double s, {
+    required Color color,
+    required double baseWidth,
+  }) {
+    final path = _buildPath(stroke, s);
+    final metrics = path.computeMetrics().toList();
+    if (metrics.isEmpty) return;
+    final m = metrics.first;
+    final length = m.length;
+    if (length < 1) return;
+
     final paint = Paint()
       ..color = color
-      ..strokeWidth = strokeWidth
-      ..strokeCap = StrokeCap.round
-      ..strokeJoin = StrokeJoin.round
-      ..style = PaintingStyle.stroke;
-    canvas.drawPath(_buildPath(stroke, s), paint);
+      ..isAntiAlias = true
+      ..style = PaintingStyle.fill;
+
+    // ~1 stamp per ~1.5 px of path length; bounded for perf.
+    final samples =
+        math.min(140, math.max(40, (length / 1.5).round()));
+
+    for (int i = 0; i <= samples; i++) {
+      final t = i / samples;
+      final tan = m.getTangentForOffset(length * t);
+      if (tan == null) continue;
+      final widthMul = _calligraphicWidthProfile(t);
+      final radius = (baseWidth * widthMul) / 2;
+      if (radius < 0.4) continue;
+      canvas.drawCircle(tan.position, radius, paint);
+    }
+  }
+
+  // Width multiplier along the stroke (t in 0..1).
+  //   pen-down ramp → full body → gradual taper → sweep-off.
+  double _calligraphicWidthProfile(double t) {
+    if (t < 0.10) {
+      return 0.65 + 0.35 * (t / 0.10);
+    } else if (t < 0.55) {
+      return 1.0;
+    } else if (t < 0.90) {
+      return 1.0 - 0.55 * ((t - 0.55) / 0.35);
+    } else {
+      return 0.45 - 0.35 * ((t - 0.90) / 0.10);
+    }
   }
 
   Path _buildPath(_Stroke stroke, double s) {


### PR DESCRIPTION
## Problem

Hiragana in the drawing game looked rigid and \"sloppy\" — like fat sausages rather than real handwriting. Strokes were rendered as monoline tubes (`Paint().strokeWidth = 12.0` with `StrokeCap.round`), which strips away all the natural rhythm of pen-down / body / harai (taper) that defines real hiragana. The underlying KanjiVG path data is correct; the rendering was the bottleneck.

## Fix

Replace the single `drawPath` line render with a calligraphic stamping routine. Sample many points along `path.computeMetrics()` and draw filled circles whose radius follows a brush profile:

| t range     | width |
|-------------|-------|
| 0.00 → 0.10 | 65% → 100% — pen lands and presses |
| 0.10 → 0.55 | 100% — body of the stroke |
| 0.55 → 0.90 | 100% → 45% — gradual fade |
| 0.90 → 1.00 | 45% → 10% — sweep-off / harai |

Base width bumped 12 → 15 to compensate for the lower average thickness.

## Test plan

- [ ] Hot-reload and open পাঠ ৪ → আঁকা → tap う — first stroke now reads as a tapered diagonal dash, not a chunky horizontal bar
- [ ] Verify shadow templates have the same tapered look (faded)
- [ ] Verify completed strokes look calligraphic with visible taper toward stroke end
- [ ] Verify green completion still works for all characters
- [ ] Verify user's in-progress finger trace is still uniform yellow (intentional — it's their actual touch input)
- [ ] Spot-check performance on a mid-tier Android device (≤120 circles per stroke per frame)

🤖 Generated with [Claude Code](https://claude.com/claude-code)