### PR TITLE
Shorten splash airplane to one pass and unify home logo

### DIFF
--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -9,6 +9,7 @@ import 'package:ez_trainz/screens/main_shell_screen.dart';
 import 'package:ez_trainz/screens/login_screen.dart';
 import 'package:ez_trainz/screens/trial_game_language_picker_screen.dart';
 import 'package:ez_trainz/widgets/streak_pill.dart';
+import 'package:ez_trainz/widgets/ez_trainz_logo_text.dart';
 
 class HomeScreen extends StatefulWidget {
   const HomeScreen({super.key});
@@ -171,27 +172,9 @@ class _HomeScreenState extends State<HomeScreen> with TickerProviderStateMixin {
                     Row(
                       mainAxisAlignment: MainAxisAlignment.spaceBetween,
                       children: [
-                        const Row(
-                          crossAxisAlignment: CrossAxisAlignment.baseline,
-                          textBaseline: TextBaseline.alphabetic,
-                          children: [
-                            Text('EZ',
-                                style: TextStyle(
-                                  color: Color(0xFFFFE000),
-                                  fontSize: 22,
-                                  fontWeight: FontWeight.w900,
-                                  height: 1,
-                                )),
-                            SizedBox(width: 3),
-                            Text('TRAINZ',
-                                style: TextStyle(
-                                  color: Colors.white,
-                                  fontSize: 20,
-                                  fontWeight: FontWeight.w800,
-                                  letterSpacing: 1.5,
-                                  height: 1,
-                                )),
-                          ],
+                        const EzTrainzLogoText(
+                          height: 30,
+                          alignment: Alignment.centerLeft,
                         ),
                         const StreakPill(),
                         GestureDetector(

--- a/lib/screens/splash_screen.dart
+++ b/lib/screens/splash_screen.dart
@@ -388,7 +388,9 @@ class _AirplaneTransitionScreenState extends State<_AirplaneTransitionScreen>
       vsync: this,
       duration: const Duration(milliseconds: 700),
     );
-    Future.delayed(const Duration(milliseconds: 3000), _navigateToDashboard);
+    // GIF is a single ~2520ms loop. Begin the fade just before it completes so
+    // the airplane only makes one pass instead of restarting a second time.
+    Future.delayed(const Duration(milliseconds: 2300), _navigateToDashboard);
   }
 
   Future<void> _navigateToDashboard() async {

--- a/lib/widgets/ez_logo_boxed.dart
+++ b/lib/widgets/ez_logo_boxed.dart
@@ -1,23 +1,34 @@
 import 'package:flutter/material.dart';
 
 class EZLogoBoxed extends StatelessWidget {
-  const EZLogoBoxed({super.key});
+  const EZLogoBoxed({
+    super.key,
+    this.width = 52,
+    this.height = 42,
+    this.fontSize = 22,
+    this.borderRadius = 8,
+  });
+
+  final double width;
+  final double height;
+  final double fontSize;
+  final double borderRadius;
 
   @override
   Widget build(BuildContext context) {
     return Container(
-      width: 52,
-      height: 42,
+      width: width,
+      height: height,
       decoration: BoxDecoration(
         color: const Color(0xFF4DA6E8),
-        borderRadius: BorderRadius.circular(8),
+        borderRadius: BorderRadius.circular(borderRadius),
       ),
-      child: const Center(
+      child: Center(
         child: Text(
           'EZ',
           style: TextStyle(
-            color: Color(0xFFFFE000),
-            fontSize: 22,
+            color: const Color(0xFFFFE000),
+            fontSize: fontSize,
             fontWeight: FontWeight.w900,
             letterSpacing: 0.5,
             height: 1,


### PR DESCRIPTION
The splash airplane GIF is a single ~2520ms loop that repeats forever. The 3000ms hold let it finish one pass and start a second before fading, which read as the plane "moving twice." Reduced the hold to 2300ms so the fade begins during the first pass — one move, then the home screen.

Also replaced the plain text logo in the home header with the same EzTrainzLogoText widget used on the program/JLC screen so the EZ TRAINZ branding is identical across screens. EZLogoBoxed gained optional sizing params (left in place, no longer used by the home header).