### PR TITLE
Tighten home screen spacing so the penguin is fully visible

### DIFF
--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -206,7 +206,7 @@ class _HomeScreenState extends State<HomeScreen> with TickerProviderStateMixin {
                       ],
                     ),
 
-                    const SizedBox(height: 36),
+                    const SizedBox(height: 16),
 
                     // ── GREETING ───────────────────────────────────
                     Text(
@@ -230,7 +230,7 @@ class _HomeScreenState extends State<HomeScreen> with TickerProviderStateMixin {
                       ),
                     ),
 
-                    const SizedBox(height: 32),
+                    const SizedBox(height: 18),
 
                     // ── TRIAL GAME CARD ─────────────────────────────
                     AnimatedBuilder(
@@ -320,7 +320,7 @@ class _HomeScreenState extends State<HomeScreen> with TickerProviderStateMixin {
                       },
                     ),
 
-                    const SizedBox(height: 28),
+                    const SizedBox(height: 14),
 
                     // ── WAVING PENGUIN ─────────────────────────────
                     Center(


### PR DESCRIPTION
## What changed

Reduced three vertical gaps on the home screen (`lib/screens/home_screen.dart`) so the program cards and the waving ninja penguin sit higher and the penguin is fully visible without scrolling:

- header → greeting: `36 → 16` (removes the blank space above the "choose a language program" subtitle)
- subtitle → cards: `32 → 18`
- cards → penguin: `28 → 14`

## Notes for reviewers

- This branch is stacked on `claude/notebook-row-picker` (PR #39), so it is based on that branch and contains only the spacing commit. If #39 merges first, GitHub will retarget this PR to `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)