### PR TITLE
UI colour redesign + per-screen ElevenLabs voice override for Hero Number 1

### DIFF
--- a/lib/config/elevenlabs_config.dart
+++ b/lib/config/elevenlabs_config.dart
@@ -12,6 +12,15 @@ class ElevenLabsConfig {
     defaultValue: 'pNInz6obpgDQGcFmaJgB',
   );
 
+  /// Optional per-screen override for Hero Number 1 pronunciations.
+  /// Set this to a Japanese female voice ID from ElevenLabs.
+  static const heroJapaneseFemaleVoiceId =
+      String.fromEnvironment('ELEVENLABS_HERO_JA_FEMALE_VOICE_ID');
+
+  static String get heroVoiceOrDefault => heroJapaneseFemaleVoiceId.isNotEmpty
+      ? heroJapaneseFemaleVoiceId
+      : voiceId;
+
   static const modelId = 'eleven_multilingual_v2';
   /// Lower bitrate reduces first-response latency on mobile networks.
   static const outputFormat = 'mp3_22050_32';

--- a/lib/screens/n5_hero_number1_lesson_screen.dart
+++ b/lib/screens/n5_hero_number1_lesson_screen.dart
@@ -5,6 +5,7 @@ import 'dart:math' as math;
 
 import 'package:confetti/confetti.dart';
 import 'package:flutter/material.dart';
+import 'package:ez_trainz/config/elevenlabs_config.dart';
 import 'package:ez_trainz/utils/app_theme.dart';
 import 'package:flutter/services.dart';
 import 'package:ez_trainz/services/jlc_tts.dart';
@@ -102,6 +103,10 @@ class _N5HeroNumber1LessonScreenState extends State<N5HeroNumber1LessonScreen> {
     );
   }
 }
+
+JlcTts _buildHeroTts() => JlcTts(
+      elevenLabsVoiceId: ElevenLabsConfig.heroVoiceOrDefault,
+    );
 
 class _HeroNum {
   const _HeroNum({
@@ -213,13 +218,9 @@ class _HeroTabPills extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     const labels = ['শুনে ট্যাপ', 'পড়া মাস্টার', 'সাজাও', '১-১০ বলো', 'বলতে পারো', 'ম্যাচ মাস্টার', 'স্পিড বস'];
-    return Container(
-      padding: const EdgeInsets.all(6),
-      decoration: BoxDecoration(
-        color: AppColors.card,
-        borderRadius: BorderRadius.circular(14),
-        border: Border.all(color: AppColors.bg),
-      ),
+    // Transparent strip so the sky→gold gradient shows behind the pills.
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: 2),
       child: SingleChildScrollView(
         scrollDirection: Axis.horizontal,
         child: Row(
@@ -229,18 +230,34 @@ class _HeroTabPills extends StatelessWidget {
                 onTap: () => onChange(i),
                 child: AnimatedContainer(
                   duration: const Duration(milliseconds: 180),
-                  padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 10),
+                  padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 10),
                   decoration: BoxDecoration(
-                    color: i == index ? const Color(0xFF3B82F6) : Colors.transparent,
-                    borderRadius: BorderRadius.circular(10),
+                    color: i == index
+                        ? AppColors.tabActive
+                        : Colors.white.withValues(alpha: 0.6),
+                    borderRadius: BorderRadius.circular(12),
+                    border: Border.all(
+                      color: i == index
+                          ? AppColors.tabActive
+                          : Colors.white.withValues(alpha: 0.75),
+                    ),
+                    boxShadow: i == index
+                        ? [
+                            BoxShadow(
+                              color: AppColors.tabActive.withValues(alpha: 0.35),
+                              blurRadius: 10,
+                              offset: const Offset(0, 4),
+                            ),
+                          ]
+                        : null,
                   ),
                   child: Text(labels[i],
                       style: TextStyle(
-                          color: i == index ? Colors.white : AppColors.textPrimary,
+                          color: i == index ? Colors.white : AppColors.display,
                           fontWeight: FontWeight.w900, fontSize: 12)),
                 ),
               ),
-              if (i != labels.length - 1) const SizedBox(width: 6),
+              if (i != labels.length - 1) const SizedBox(width: 8),
             ]
           ],
         ),
@@ -259,7 +276,7 @@ class _HeroSpeakGame extends StatefulWidget {
 class _HeroSpeakGameState extends State<_HeroSpeakGame>
     with TickerProviderStateMixin {
   final _rng = math.Random();
-  final _tts = JlcTts();
+  final _tts = _buildHeroTts();
   final _stt = JlcStt();
   bool _ttsReady = false;
   bool _sttReady = false;
@@ -1004,7 +1021,7 @@ class _MicButton extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final base = listening ? const Color(0xFFEF4444) : const Color(0xFFFF6B35);
+    final base = listening ? const Color(0xFFEF4444) : AppColors.audio;
     return GestureDetector(
       onTap: onTap,
       child: AnimatedBuilder(
@@ -1208,7 +1225,7 @@ class _HeroMatchGame extends StatefulWidget {
 class _HeroMatchGameState extends State<_HeroMatchGame>
     with TickerProviderStateMixin {
   final _rng = math.Random();
-  final _tts = JlcTts();
+  final _tts = _buildHeroTts();
   late ConfettiController _confetti;
   late AnimationController _shakeCtrl;
   bool _ttsReady = false;
@@ -1506,7 +1523,7 @@ class _HeroMatchGameState extends State<_HeroMatchGame>
                           ? const Color(0xFFEF4444).withValues(alpha: 0.18)
                           : (selected
                               ? const Color(0xFFFFE000).withValues(alpha: 0.14)
-                              : AppColors.bg);
+                              : AppColors.card);
                   return AnimatedBuilder(
                     animation: _shakeCtrl,
                     builder: (_, child) {
@@ -1528,6 +1545,7 @@ class _HeroMatchGameState extends State<_HeroMatchGame>
                             border: Border.all(
                                 color: border,
                                 width: selected || wrong ? 2.4 : 1.5),
+                            boxShadow: _softShadow,
                           ),
                           child: Stack(
                             children: [
@@ -1638,7 +1656,7 @@ class _HeroBlitzGame extends StatefulWidget {
 class _HeroBlitzGameState extends State<_HeroBlitzGame>
     with TickerProviderStateMixin {
   final _rng = math.Random();
-  final _tts = JlcTts();
+  final _tts = _buildHeroTts();
   late ConfettiController _confetti;
   late AnimationController _shakeCtrl;
   static const _totalSeconds = 25;
@@ -1891,15 +1909,12 @@ class _HeroBlitzGameState extends State<_HeroBlitzGame>
                               padding: const EdgeInsets.symmetric(
                                   horizontal: 14, vertical: 12),
                               decoration: BoxDecoration(
-                                gradient: LinearGradient(
+                                gradient: const LinearGradient(
                                   begin: Alignment.topLeft,
                                   end: Alignment.bottomRight,
                                   colors: [
-                                    (_timeLeft <= 5
-                                            ? const Color(0xFFEF4444)
-                                            : const Color(0xFFFFE000))
-                                        .withValues(alpha: 0.22),
-                                    AppColors.bg,
+                                    AppColors.timerTrack,
+                                    Color(0xFF0F172A),
                                   ],
                                 ),
                                 borderRadius: BorderRadius.circular(16),
@@ -1908,7 +1923,7 @@ class _HeroBlitzGameState extends State<_HeroBlitzGame>
                                       ? const Color(0xFFFF6B6B)
                                           .withValues(alpha: 0.9)
                                       : const Color(0xFFFFE000)
-                                          .withValues(alpha: 0.85),
+                                          .withValues(alpha: 0.55),
                                   width: 2,
                                 ),
                               ),
@@ -1929,7 +1944,7 @@ class _HeroBlitzGameState extends State<_HeroBlitzGame>
                                     children: [
                                       Text('মোট সময়',
                                           style: TextStyle(
-                                              color: AppColors.border,
+                                              color: Color(0xFFCBD5E1),
                                               fontWeight: FontWeight.w800,
                                               fontSize: 11)),
                                       Text('$_timeLeft',
@@ -1942,7 +1957,7 @@ class _HeroBlitzGameState extends State<_HeroBlitzGame>
                                               height: 1)),
                                       Text('সেকেন্ড বাকি',
                                           style: TextStyle(
-                                              color: AppColors.border,
+                                              color: Color(0xFFCBD5E1),
                                               fontWeight: FontWeight.w700,
                                               fontSize: 12)),
                                     ],
@@ -1984,22 +1999,21 @@ class _HeroBlitzGameState extends State<_HeroBlitzGame>
                               padding: const EdgeInsets.symmetric(
                                   horizontal: 14, vertical: 8),
                               decoration: BoxDecoration(
-                                color: const Color(0xFFFFE000)
-                                    .withValues(alpha: 0.18),
+                                color: AppColors.audio.withValues(alpha: 0.12),
                                 borderRadius: BorderRadius.circular(99),
                                 border: Border.all(
-                                    color: const Color(0xFFFFE000)
-                                        .withValues(alpha: 0.6)),
+                                    color: AppColors.audio
+                                        .withValues(alpha: 0.5)),
                               ),
                               child: const Row(
                                 mainAxisSize: MainAxisSize.min,
                                 children: [
                                   Icon(Icons.volume_up_rounded,
-                                      color: Color(0xFFFFE000), size: 18),
+                                      color: AppColors.audio, size: 18),
                                   SizedBox(width: 6),
                                   Text('শুনি',
                                       style: TextStyle(
-                                          color: Color(0xFFFFE000),
+                                          color: AppColors.audio,
                                           fontWeight: FontWeight.w900)),
                                 ],
                               ),
@@ -2047,7 +2061,7 @@ class _HeroBlitzGameState extends State<_HeroBlitzGame>
                       const SizedBox(height: 8),
                       const Text('সঠিক বাংলা সংখ্যা বেছে নাও',
                           style: TextStyle(
-                              color: Color(0xFFFFE000),
+                              color: AppColors.instruction,
                               fontWeight: FontWeight.w900)),
                     ],
                   ),
@@ -2068,13 +2082,13 @@ class _HeroBlitzGameState extends State<_HeroBlitzGame>
                     final picked = _picked == o.n;
                     final correct = o.n == _target.n;
                     final bg = _picked == null
-                        ? AppColors.bg
+                        ? AppColors.card
                         : (correct
                             ? const Color(0xFF10B981).withValues(alpha: 0.22)
                             : (picked
                                 ? const Color(0xFFEF4444)
                                     .withValues(alpha: 0.22)
-                                : AppColors.bg));
+                                : AppColors.card));
                     final border = _picked == null
                         ? AppColors.border
                         : (correct
@@ -2094,6 +2108,7 @@ class _HeroBlitzGameState extends State<_HeroBlitzGame>
                             border: Border.all(
                                 color: border,
                                 width: _picked == null ? 1 : 2),
+                            boxShadow: _softShadow,
                           ),
                           child: Center(
                             child: Text('${o.bnDigit} ${o.bnWord}',
@@ -2161,7 +2176,7 @@ class _HeroTapWhatYouHearGameState extends State<_HeroTapWhatYouHearGame>
   static const _sessionXpBonus = 50;
 
   final _rng = math.Random();
-  final _tts = JlcTts();
+  final _tts = _buildHeroTts();
   late final Future<void> _ttsReady;
   late ConfettiController _confetti;
   late AnimationController _shakeCtrl;
@@ -2346,7 +2361,7 @@ class _HeroTapWhatYouHearGameState extends State<_HeroTapWhatYouHearGame>
     Color textColor = AppColors.textPrimary;
     if (!revealed) {
       border = AppColors.border;
-      bg = AppColors.bg;
+      bg = AppColors.card;
     } else if (isCorrect) {
       border = const Color(0xFF10B981);
       bg = const Color(0xFF10B981).withValues(alpha: 0.22);
@@ -2357,7 +2372,7 @@ class _HeroTapWhatYouHearGameState extends State<_HeroTapWhatYouHearGame>
       textColor = const Color(0xFFEF4444);
     } else {
       border = AppColors.border;
-      bg = AppColors.bg;
+      bg = AppColors.card;
     }
 
     return Expanded(
@@ -2374,6 +2389,7 @@ class _HeroTapWhatYouHearGameState extends State<_HeroTapWhatYouHearGame>
                 color: border,
                 width: (picked || (isCorrect && revealed)) ? 2.2 : 1.2,
               ),
+              boxShadow: _softShadow,
             ),
             child: Row(
               mainAxisAlignment: MainAxisAlignment.center,
@@ -2414,7 +2430,7 @@ class _HeroTapWhatYouHearGameState extends State<_HeroTapWhatYouHearGame>
 
   @override
   Widget build(BuildContext context) {
-    const orange = Color(0xFFFF8A34);
+    const orange = AppColors.audio;
     final progress = (_roundIdx + 1) / _totalRounds;
 
     return Padding(
@@ -2555,7 +2571,7 @@ class _HeroTapWhatYouHearGameState extends State<_HeroTapWhatYouHearGame>
                         child: Text(
                           _target.bnPronunciation,
                           style: const TextStyle(
-                            color: Color(0xFFFFE000),
+                            color: AppColors.display,
                             fontSize: 44,
                             fontWeight: FontWeight.w900,
                           ),
@@ -2618,7 +2634,7 @@ class _HeroTapWhatYouHearGameState extends State<_HeroTapWhatYouHearGame>
               const Text(
                 'এইবার আপনি বলেন সঠিক উত্তর কোনটি?',
                 style: TextStyle(
-                  color: AppColors.textPrimary,
+                  color: AppColors.instruction,
                   fontSize: 14,
                   fontWeight: FontWeight.w900,
                 ),
@@ -2741,7 +2757,7 @@ class _HeroReadGameState extends State<_HeroReadGame>
   static const _violetDark = Color(0xFF6D28D9);
 
   final _rng = math.Random();
-  final _tts = JlcTts();
+  final _tts = _buildHeroTts();
   late final Future<void> _ttsReady;
   late ConfettiController _confetti;
   late AnimationController _shakeCtrl;
@@ -3138,7 +3154,7 @@ class _HeroReadGameState extends State<_HeroReadGame>
               Text(
                 _questionText,
                 style: const TextStyle(
-                  color: AppColors.textPrimary,
+                  color: AppColors.instruction,
                   fontSize: 14,
                   fontWeight: FontWeight.w900,
                 ),
@@ -3270,7 +3286,7 @@ class _HeroReadGameState extends State<_HeroReadGame>
         return Text(
           _target.bnPronunciation,
           style: const TextStyle(
-            color: Color(0xFFFFE000),
+            color: AppColors.display,
             fontSize: 56,
             fontWeight: FontWeight.w900,
             height: 1.05,
@@ -3331,7 +3347,7 @@ class _HeroReadGameState extends State<_HeroReadGame>
     Color textColor = AppColors.textPrimary;
     if (!revealed) {
       border = AppColors.border;
-      bg = AppColors.bg;
+      bg = AppColors.card;
     } else if (isCorrect) {
       border = const Color(0xFF10B981);
       bg = const Color(0xFF10B981).withValues(alpha: 0.22);
@@ -3342,7 +3358,7 @@ class _HeroReadGameState extends State<_HeroReadGame>
       textColor = const Color(0xFFEF4444);
     } else {
       border = AppColors.border;
-      bg = AppColors.bg;
+      bg = AppColors.card;
     }
 
     // Option label depends on mode
@@ -3367,6 +3383,7 @@ class _HeroReadGameState extends State<_HeroReadGame>
                 color: border,
                 width: (picked || (isCorrect && revealed)) ? 2.4 : 1.2,
               ),
+              boxShadow: _softShadow,
             ),
             child: Row(
               mainAxisAlignment: MainAxisAlignment.center,
@@ -3729,7 +3746,7 @@ class _HeroOrderGameState extends State<_HeroOrderGame>
             bg = _teal.withValues(alpha: 0.18);
           } else {
             border = AppColors.border;
-            bg = AppColors.bg;
+            bg = AppColors.card;
           }
           return AnimatedContainer(
             duration: const Duration(milliseconds: 160),
@@ -3741,6 +3758,7 @@ class _HeroOrderGameState extends State<_HeroOrderGame>
                 color: border,
                 width: hovering || isFilled ? 2.2 : 1.2,
               ),
+              boxShadow: _softShadow,
             ),
             child: Row(
               children: [
@@ -3791,7 +3809,7 @@ class _HeroOrderGameState extends State<_HeroOrderGame>
                                   Text(
                                     '${placed.kanji}  ${placed.kana}',
                                     style: TextStyle(
-                                      color: AppColors.border,
+                                      color: AppColors.textMuted,
                                       fontSize: 11,
                                       fontWeight: FontWeight.w700,
                                       height: 1.0,
@@ -3902,7 +3920,7 @@ class _HeroSpeakSequenceGameState extends State<_HeroSpeakSequenceGame>
   static const _roseDark = Color(0xFFBE123C);
 
   final _stt = JlcStt();
-  final _tts = JlcTts();
+  final _tts = _buildHeroTts();
   bool _sttReady = false;
   bool _ttsReady = false;
   String? _locale;
@@ -4572,7 +4590,7 @@ class _HeroSpeakSequenceGameState extends State<_HeroSpeakSequenceGame>
                 _heard,
                 textAlign: TextAlign.center,
                 style: const TextStyle(
-                  color: Color(0xFFFFE000),
+                  color: AppColors.display,
                   fontWeight: FontWeight.w900,
                   fontSize: 14,
                   height: 1.3,
@@ -4877,12 +4895,12 @@ class _AwesomeResultSheet extends StatelessWidget {
         margin: const EdgeInsets.fromLTRB(16, 0, 16, 16),
         padding: const EdgeInsets.all(16),
         decoration: BoxDecoration(
-          color: const Color(0xFF0B1326),
+          color: AppColors.card,
           borderRadius: BorderRadius.circular(22),
-          border: Border.all(color: const Color(0xFFFFE000).withValues(alpha: 0.18)),
+          border: Border.all(color: AppColors.border),
           boxShadow: [
             BoxShadow(
-              color: Colors.black.withValues(alpha: 0.35),
+              color: Colors.black.withValues(alpha: 0.18),
               blurRadius: 22,
               offset: const Offset(0, 12),
             )
@@ -4918,7 +4936,7 @@ class _AwesomeResultSheet extends StatelessWidget {
                 crossAxisAlignment: CrossAxisAlignment.start,
                 children: [
                   Text(scoreLabel,
-                      style: const TextStyle(color: Color(0xFFFFE000), fontWeight: FontWeight.w900, fontSize: 22)),
+                      style: const TextStyle(color: AppColors.display, fontWeight: FontWeight.w900, fontSize: 22)),
                   const SizedBox(height: 10),
                   Wrap(
                     spacing: 8,
@@ -4985,8 +5003,14 @@ class _AwesomeResultSheet extends StatelessWidget {
   }
 }
 
+/// Subtle drop shadow that lifts white cards/option tiles off the gradient.
+const List<BoxShadow> _softShadow = [
+  BoxShadow(color: Color(0x0D0F172A), blurRadius: 6, offset: Offset(0, 4)),
+];
+
 BoxDecoration _cardDeco() => BoxDecoration(
       color: AppColors.card,
       borderRadius: BorderRadius.circular(16),
       border: Border.all(color: AppColors.border),
+      boxShadow: _softShadow,
     );

--- a/lib/services/elevenlabs_tts_service.dart
+++ b/lib/services/elevenlabs_tts_service.dart
@@ -29,16 +29,19 @@ class ElevenLabsTtsService {
   void setStartHandler(VoidCallback? handler) => _onStart = handler;
   void setCompletionHandler(VoidCallback? handler) => _onComplete = handler;
 
-  Future<void> prefetchTexts(Iterable<String> texts) async {
+  Future<void> prefetchTexts(
+    Iterable<String> texts, {
+    String? voiceId,
+  }) async {
     if (!isAvailable) return;
     for (final raw in texts) {
       final text = raw.trim();
       if (text.isEmpty) continue;
       try {
         if (kIsWeb) {
-          await _fetchAudio(text);
+          await _fetchAudio(text, voiceId: voiceId);
         } else {
-          await _ensureLocalFile(text);
+          await _ensureLocalFile(text, voiceId: voiceId);
         }
       } catch (_) {
         // Ignore per-item failures during background prefetch.
@@ -71,6 +74,7 @@ class ElevenLabsTtsService {
   Future<void> speak(
     String text, {
     double playbackRate = 1.0,
+    String? voiceId,
   }) async {
     final trimmed = text.trim();
     if (trimmed.isEmpty || !isAvailable) {
@@ -80,43 +84,54 @@ class ElevenLabsTtsService {
     await _player.stop();
     await _player.setPlaybackRate(playbackRate.clamp(0.5, 1.25));
     _onStart?.call();
-    await _player.play(await _sourceForText(trimmed));
+    await _player.play(await _sourceForText(trimmed, voiceId: voiceId));
     await _player.onPlayerComplete.first;
     _onComplete?.call();
   }
 
   /// iOS AVPlayer needs a real `.mp3` file; in-memory bytes fail on device.
-  Future<Source> _sourceForText(String text) async {
-    if (kIsWeb) return BytesSource(await _fetchAudio(text));
+  Future<Source> _sourceForText(
+    String text, {
+    String? voiceId,
+  }) async {
+    if (kIsWeb) return BytesSource(await _fetchAudio(text, voiceId: voiceId));
 
-    final path = await _ensureLocalFile(text);
+    final path = await _ensureLocalFile(text, voiceId: voiceId);
     return DeviceFileSource(path, mimeType: 'audio/mpeg');
   }
 
-  Future<String> _ensureLocalFile(String text) async {
-    final path = await _cachedPath(text);
+  Future<String> _ensureLocalFile(
+    String text, {
+    String? voiceId,
+  }) async {
+    final key = _cacheKey(text, voiceId: voiceId);
+    final path = await _cachedPath(text, voiceId: voiceId);
     if (File(path).existsSync()) return path;
 
-    final inFlight = _inFlightFiles[text];
+    final inFlight = _inFlightFiles[key];
     if (inFlight != null) return inFlight;
 
     final future = () async {
-      final bytes = await _fetchAudio(text);
+      final bytes = await _fetchAudio(text, voiceId: voiceId);
       await File(path).writeAsBytes(bytes, flush: true);
       return path;
     }();
-    _inFlightFiles[text] = future;
+    _inFlightFiles[key] = future;
     try {
       return await future;
     } finally {
-      _inFlightFiles.remove(text);
+      _inFlightFiles.remove(key);
     }
   }
 
-  Future<String> _cachedPath(String text) async {
+  Future<String> _cachedPath(
+    String text, {
+    String? voiceId,
+  }) async {
     final dir = await getTemporaryDirectory();
+    final resolvedVoiceId = _resolveVoiceId(voiceId);
     final key = _stableHash(
-      '$text|${ElevenLabsConfig.voiceId}|${ElevenLabsConfig.modelId}|${ElevenLabsConfig.outputFormat}',
+      '$text|$resolvedVoiceId|${ElevenLabsConfig.modelId}|${ElevenLabsConfig.outputFormat}',
     );
     return '${dir.path}/el_$key.mp3';
   }
@@ -134,24 +149,32 @@ class ElevenLabsTtsService {
     return hash.toRadixString(16);
   }
 
-  Future<Uint8List> _fetchAudio(String text) async {
-    final cached = _webCache[text];
+  Future<Uint8List> _fetchAudio(
+    String text, {
+    String? voiceId,
+  }) async {
+    final key = _cacheKey(text, voiceId: voiceId);
+    final cached = _webCache[key];
     if (cached != null) return cached;
-    final inFlight = _inFlight[text];
+    final inFlight = _inFlight[key];
     if (inFlight != null) return inFlight;
 
-    final future = _fetchAudioRemote(text);
-    _inFlight[text] = future;
+    final future = _fetchAudioRemote(text, voiceId: voiceId);
+    _inFlight[key] = future;
     try {
       return await future;
     } finally {
-      _inFlight.remove(text);
+      _inFlight.remove(key);
     }
   }
 
-  Future<Uint8List> _fetchAudioRemote(String text) async {
+  Future<Uint8List> _fetchAudioRemote(
+    String text, {
+    String? voiceId,
+  }) async {
+    final resolvedVoiceId = _resolveVoiceId(voiceId);
     final uri = Uri.parse(
-      'https://api.elevenlabs.io/v1/text-to-speech/${ElevenLabsConfig.voiceId}',
+      'https://api.elevenlabs.io/v1/text-to-speech/$resolvedVoiceId',
     ).replace(queryParameters: {
       'output_format': ElevenLabsConfig.outputFormat,
       // Higher values optimize for lower latency.
@@ -188,8 +211,22 @@ class ElevenLabsTtsService {
     }
 
     final bytes = response.bodyBytes;
-    _webCache[text] = bytes;
+    _webCache[_cacheKey(text, voiceId: voiceId)] = bytes;
     return bytes;
+  }
+
+  String _resolveVoiceId(String? overrideVoiceId) {
+    final trimmed = overrideVoiceId?.trim() ?? '';
+    if (trimmed.isNotEmpty) return trimmed;
+    return ElevenLabsConfig.voiceId;
+  }
+
+  String _cacheKey(
+    String text, {
+    String? voiceId,
+  }) {
+    final resolvedVoiceId = _resolveVoiceId(voiceId);
+    return '$text|$resolvedVoiceId';
   }
 
   void dispose() {

--- a/lib/services/jlc_tts.dart
+++ b/lib/services/jlc_tts.dart
@@ -8,7 +8,9 @@ import 'package:ez_trainz/services/elevenlabs_tts_service.dart';
 /// Drop-in replacement for [FlutterTts] on JLC screens.
 /// Uses ElevenLabs Japanese voices when configured; falls back to device TTS.
 class JlcTts {
-  JlcTts() : _fallback = FlutterTts() {
+  JlcTts({String? elevenLabsVoiceId})
+      : _fallback = FlutterTts(),
+        _elevenLabsVoiceId = elevenLabsVoiceId?.trim() {
     if (_useElevenLabs) {
       unawaited(ElevenLabsTtsService.instance.prewarm());
       _prefetchCommonPackOnce();
@@ -16,6 +18,7 @@ class JlcTts {
   }
 
   final FlutterTts _fallback;
+  final String? _elevenLabsVoiceId;
   bool _awaitCompletion = false;
   double _speechRate = 0.5;
   VoidCallback? _startHandler;
@@ -107,13 +110,17 @@ class JlcTts {
     unawaited(
       ElevenLabsTtsService.instance.prefetchTexts(
         _commonJapanesePack.expand((t) => <String>[t, '$t。']),
+        voiceId: _elevenLabsVoiceId,
       ),
     );
   }
 
   Future<void> prefetchTexts(Iterable<String> texts) async {
     if (!_useElevenLabs) return;
-    await ElevenLabsTtsService.instance.prefetchTexts(texts);
+    await ElevenLabsTtsService.instance.prefetchTexts(
+      texts,
+      voiceId: _elevenLabsVoiceId,
+    );
   }
 
   Future<void> setLanguage(String language) async {
@@ -185,6 +192,7 @@ class JlcTts {
         await ElevenLabsTtsService.instance.speak(
           text,
           playbackRate: _speechRateToPlayback(_speechRate),
+          voiceId: _elevenLabsVoiceId,
         );
         return;
       } catch (e) {

--- a/lib/utils/app_theme.dart
+++ b/lib/utils/app_theme.dart
@@ -42,6 +42,15 @@ abstract class AppColors {
   static const correct = Color(0xFF14B86A);
   static const wrong   = Color(0xFFE53935);
 
+  // ── Cohesive light-UI tokens ─────────────────────────────────
+  // Used by the gradient game screens so display text stays readable
+  // against the sky-blue → golden-yellow background.
+  static const display     = Color(0xFF0F172A); // deep midnight navy — large display text
+  static const instruction = Color(0xFF334155); // slate charcoal — instructional / prompt text
+  static const tabActive   = Color(0xFF2563EB); // royal blue — active nav tab
+  static const audio       = Color(0xFFEA580C); // deep amber/coral — speaker & mic buttons
+  static const timerTrack  = Color(0xFF1E293B); // dark blue-gray — countdown track
+
   // ── Legacy aliases ───────────────────────────────────────────
   // Old code referenced navy* tokens; keep them pointing at the new light
   // surfaces so everything compiles while screens are migrated.


### PR DESCRIPTION
## Summary

- **UI colour redesign** — fixes severe readability issues on the sky-blue → golden-yellow gradient background in the Hero Number 1 lesson (`N5HeroNumber1LessonScreen`), across all 7 game modes.
- **Per-screen ElevenLabs voice** — threads a `voiceId` override through `ElevenLabsTtsService` and `JlcTts` so the Hero screen can use a dedicated Japanese-female voice without affecting other screens.

---

## UI Changes (`lib/screens/n5_hero_number1_lesson_screen.dart`, `lib/utils/app_theme.dart`)

Five new palette tokens added to `AppColors`:

| Token | Hex | Where used |
|---|---|---|
| `display` | `#0F172A` deep midnight navy | Large pronunciation text (রোকু, নানা, etc.) |
| `instruction` | `#334155` slate charcoal | Instructional lines ("এইবার আপনি বলেন…") |
| `tabActive` | `#2563EB` royal blue | Active game-mode tab pill |
| `audio` | `#EA580C` deep amber-coral | Speaker & mic buttons |
| `timerTrack` | `#1E293B` dark blue-gray | Speed-run countdown background |

Key fixes:
- **Main display text** — Bengali pronunciation (রোকু/নানা) was bright yellow `#FFE000` on a yellow-tinted pill → now deep navy for maximum contrast (listen-tap, read-master modes).
- **Tab pills** — now monochromatic blue: active = solid royal-blue, inactive = translucent-white (gradient shows through), no more conflicting greys.
- **Option/choice cards** — base state changed from `AppColors.bg` (light blue) to `AppColors.card` (pure white) + uniform soft drop-shadow (`rgba(15,23,42,0.05)`) in all 4 game modes that have MCQ tiles.
- **Speed-run countdown** — timer box background changed from pale yellow-tinted to dark blue-gray so the yellow seconds counter stays vivid as it ticks.
- **Mic & speaker buttons** — brightness-matched amber/coral replaces the low-contrast orange.
- **Result bottom-sheet** — was white text on near-black `#0B1326` (invisible in light mode) → now light card surface, consistent with the rest of the screen.
- **Shared `_softShadow` constant** — single source of truth for the card drop-shadow, applied to all 7 option/tile surfaces.

---

## TTS Changes (`lib/services/elevenlabs_tts_service.dart`, `lib/services/jlc_tts.dart`, `lib/config/elevenlabs_config.dart`)

- `ElevenLabsTtsService.speak/prefetchTexts` now accept an optional `voiceId` parameter; falls back to `ElevenLabsConfig.voiceId` when `null`.
- Cache keys updated to include the resolved voice ID so clips for different voices never collide in the on-disk or in-memory cache.
- `JlcTts` constructor gains an optional `elevenLabsVoiceId` parameter and threads it through all call sites.
- `ElevenLabsConfig.heroVoiceOrDefault` reads `ELEVENLABS_HERO_JA_FEMALE_VOICE_ID` from the environment; if unset, falls back to the default voice — so no behaviour change until the env-var is configured.
- A top-level `_buildHeroTts()` helper instantiates `JlcTts` with the hero voice for the 6 game-state classes in the Hero screen.

---

## Test plan

- [ ] Run on iOS/Android device and open Hero Number 1 lesson
- [ ] Check all 7 tabs: שUNE TAP, READ MASTER, ORDER, 1–10 SPEAK, CAN SPEAK, MATCH MASTER, SPEED BOSS
- [ ] Verify pronunciation text (রোকু, নানা, etc.) is readable (dark navy) against the gradient at all scroll positions
- [ ] Verify active tab pill is royal blue; inactive pills show the gradient behind them
- [ ] Verify option/choice cards render white with a subtle shadow and correct green/red feedback on answer
- [ ] Speed-run: countdown number is clearly visible against the dark timer box
- [ ] Audio buttons are amber/coral (not bright orange or yellow)
- [ ] Result sheet (bottom modal) renders correctly on light background
- [ ] `flutter analyze` — 0 errors (only pre-existing `info` lints unchanged)
- [ ] (Optional) Set `ELEVENLABS_HERO_JA_FEMALE_VOICE_ID=<voice_id>` and confirm Hero screen uses the override voice; other screens still use the default

🤖 Generated with [Claude Code](https://claude.com/claude-code)