### PR TITLE
Fix TTS loudness, JP number pronunciation, and recolor Order game

### DIFF
--- a/lib/screens/n5_hero_number1_lesson_screen.dart
+++ b/lib/screens/n5_hero_number1_lesson_screen.dart
@@ -3427,8 +3427,9 @@ class _HeroOrderGame extends StatefulWidget {
 
 class _HeroOrderGameState extends State<_HeroOrderGame>
     with TickerProviderStateMixin {
-  static const _teal = Color(0xFF14B8A6);
-  static const _tealDark = Color(0xFF0F766E);
+  // Royal blue — matches the active tab and the app palette.
+  static const _accent = Color(0xFF2563EB);
+  static const _accentDark = Color(0xFF1D4ED8);
   static const _sessionXpBonus = 50;
 
   final _rng = math.Random();
@@ -3572,7 +3573,7 @@ class _HeroOrderGameState extends State<_HeroOrderGame>
                   colors: const [
                     Color(0xFFFFE000),
                     Color(0xFF10B981),
-                    _teal,
+                    _accent,
                     Color(0xFF3B82F6),
                   ],
                 ),
@@ -3587,10 +3588,10 @@ class _HeroOrderGameState extends State<_HeroOrderGame>
                 decoration: BoxDecoration(
                   color: AppColors.card,
                   borderRadius: BorderRadius.circular(16),
-                  border: Border.all(color: _teal.withValues(alpha: 0.45)),
+                  border: Border.all(color: _accent.withValues(alpha: 0.45)),
                   boxShadow: [
                     BoxShadow(
-                      color: _teal.withValues(alpha: 0.12),
+                      color: _accent.withValues(alpha: 0.12),
                       blurRadius: 18,
                       offset: const Offset(0, 8),
                     ),
@@ -3602,7 +3603,7 @@ class _HeroOrderGameState extends State<_HeroOrderGame>
                     Row(
                       children: [
                         const Icon(Icons.format_list_numbered_rounded,
-                            color: _teal, size: 22),
+                            color: _accent, size: 22),
                         const SizedBox(width: 8),
                         const Expanded(
                           child: Text(
@@ -3628,7 +3629,7 @@ class _HeroOrderGameState extends State<_HeroOrderGame>
                       borderRadius: BorderRadius.circular(99),
                       value: progress.clamp(0, 1),
                       backgroundColor: AppColors.border,
-                      valueColor: const AlwaysStoppedAnimation(_teal),
+                      valueColor: const AlwaysStoppedAnimation(_accent),
                     ),
                     const SizedBox(height: 8),
                     Row(
@@ -3742,8 +3743,8 @@ class _HeroOrderGameState extends State<_HeroOrderGame>
             border = const Color(0xFF10B981);
             bg = const Color(0xFF10B981).withValues(alpha: 0.18);
           } else if (hovering) {
-            border = _teal;
-            bg = _teal.withValues(alpha: 0.18);
+            border = _accent;
+            bg = _accent.withValues(alpha: 0.18);
           } else {
             border = AppColors.border;
             bg = AppColors.card;
@@ -3771,7 +3772,7 @@ class _HeroOrderGameState extends State<_HeroOrderGame>
                         ? const LinearGradient(
                             colors: [Color(0xFF10B981), Color(0xFF059669)])
                         : const LinearGradient(
-                            colors: [_teal, _tealDark]),
+                            colors: [_accent, _accentDark]),
                     borderRadius: BorderRadius.circular(10),
                   ),
                   child: Text(
@@ -3828,7 +3829,7 @@ class _HeroOrderGameState extends State<_HeroOrderGame>
                           hovering ? 'এখানে বসান' : 'এখানে টেনে আনুন',
                           style: TextStyle(
                             color: hovering
-                                ? _teal
+                                ? _accent
                                 : AppColors.textMuted,
                             fontSize: 12,
                             fontWeight: FontWeight.w700,
@@ -3851,14 +3852,14 @@ class _HeroOrderGameState extends State<_HeroOrderGame>
       padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 10),
       decoration: BoxDecoration(
         gradient: const LinearGradient(
-          colors: [_teal, _tealDark],
+          colors: [_accent, _accentDark],
           begin: Alignment.topLeft,
           end: Alignment.bottomRight,
         ),
         borderRadius: BorderRadius.circular(99),
         boxShadow: [
           BoxShadow(
-            color: _teal.withValues(alpha: 0.35),
+            color: _accent.withValues(alpha: 0.35),
             blurRadius: 10,
             offset: const Offset(0, 4),
           ),

--- a/lib/services/elevenlabs_tts_service.dart
+++ b/lib/services/elevenlabs_tts_service.dart
@@ -15,6 +15,26 @@ class ElevenLabsTtsService {
   static final ElevenLabsTtsService instance = ElevenLabsTtsService._();
 
   final AudioPlayer _player = AudioPlayer();
+
+  /// Forces playback through the loud speaker at media volume.
+  ///
+  /// audioplayers defaults the iOS audio session to `playAndRecord`, which
+  /// routes audio to the quiet earpiece — and the mic (STT, via the `record`
+  /// package) leaves the shared session in that state. The `playback` category
+  /// keeps every clip on the main speaker and ignores the Ring/Silent switch.
+  static final AudioContext _playbackContext = AudioContext(
+    iOS: AudioContextIOS(
+      category: AVAudioSessionCategory.playback,
+      options: const {AVAudioSessionOptions.mixWithOthers},
+    ),
+    android: const AudioContextAndroid(
+      contentType: AndroidContentType.music,
+      usageType: AndroidUsageType.media,
+      audioFocus: AndroidAudioFocus.gain,
+    ),
+  );
+  double _volume = 1.0;
+
   final http.Client _client = http.Client();
   final Map<String, Uint8List> _webCache = {};
   final Map<String, Future<Uint8List>> _inFlight = {};
@@ -71,6 +91,14 @@ class ElevenLabsTtsService {
     await _player.stop();
   }
 
+  /// Sets the playback volume (0.0–1.0). Defaults to full volume.
+  Future<void> setVolume(double volume) async {
+    _volume = volume.clamp(0.0, 1.0);
+    try {
+      await _player.setVolume(_volume);
+    } catch (_) {}
+  }
+
   Future<void> speak(
     String text, {
     double playbackRate = 1.0,
@@ -82,6 +110,12 @@ class ElevenLabsTtsService {
     }
 
     await _player.stop();
+    // Re-assert the loud-speaker route on every clip: the mic (STT) flips the
+    // shared iOS session to the earpiece, so we reset it right before playing.
+    try {
+      await _player.setAudioContext(_playbackContext);
+    } catch (_) {}
+    await _player.setVolume(_volume);
     await _player.setPlaybackRate(playbackRate.clamp(0.5, 1.25));
     _onStart?.call();
     await _player.play(await _sourceForText(trimmed, voiceId: voiceId));
@@ -130,8 +164,11 @@ class ElevenLabsTtsService {
   }) async {
     final dir = await getTemporaryDirectory();
     final resolvedVoiceId = _resolveVoiceId(voiceId);
+    final primed = _primeJapanese(text);
+    final base =
+        '${primed.text}|$resolvedVoiceId|${ElevenLabsConfig.modelId}|${ElevenLabsConfig.outputFormat}';
     final key = _stableHash(
-      '$text|$resolvedVoiceId|${ElevenLabsConfig.modelId}|${ElevenLabsConfig.outputFormat}',
+      primed.isPlain ? base : '$base|ctx:${primed.previousText ?? ''}|stable',
     );
     return '${dir.path}/el_$key.mp3';
   }
@@ -173,6 +210,7 @@ class ElevenLabsTtsService {
     String? voiceId,
   }) async {
     final resolvedVoiceId = _resolveVoiceId(voiceId);
+    final primed = _primeJapanese(text);
     final uri = Uri.parse(
       'https://api.elevenlabs.io/v1/text-to-speech/$resolvedVoiceId',
     ).replace(queryParameters: {
@@ -190,16 +228,26 @@ class ElevenLabsTtsService {
         'Accept': 'audio/mpeg',
       },
       body: jsonEncode({
-        'text': text,
+        'text': primed.text,
         'model_id': ElevenLabsConfig.modelId,
         'language_code': 'ja',
         'apply_language_text_normalization': true,
-        'voice_settings': {
-          'stability': 0.42,
-          'similarity_boost': 0.78,
-          'style': 0.15,
-          'use_speaker_boost': true,
-        },
+        // Counting context (not spoken) — forces the number reading of さん etc.
+        if (primed.previousText != null) 'previous_text': primed.previousText,
+        // Calm settings hold the vowel for crisp single-word readings.
+        'voice_settings': primed.stable
+            ? {
+                'stability': 0.65,
+                'similarity_boost': 0.80,
+                'style': 0.0,
+                'use_speaker_boost': true,
+              }
+            : {
+                'stability': 0.42,
+                'similarity_boost': 0.78,
+                'style': 0.15,
+                'use_speaker_boost': true,
+              },
       }),
     )
         .timeout(const Duration(seconds: 20));
@@ -215,6 +263,56 @@ class ElevenLabsTtsService {
     return bytes;
   }
 
+  /// Japanese number readings 1–10, in counting order.
+  static const List<String> _jaNumberReadings = <String>[
+    'いち', 'に', 'さん', 'よん', 'ご', 'ろく', 'なな', 'はち', 'きゅう', 'じゅう',
+  ];
+
+  /// Stabilizes pronunciation of short, ambiguous Japanese number words.
+  ///
+  /// A bare 2-mora word like さん has no context and drifts toward せん (1000)
+  /// under the expressive default settings. For the 1–10 readings we:
+  ///   • prime the model with the preceding numbers via `previous_text`
+  ///     (NOT spoken) so it reads さん as *three*, like 三;
+  ///   • append a sentence-final 。for a stable falling intonation;
+  ///   • flag `stable` so the request uses calm settings (style 0, higher
+  ///     stability) that hold the open "あ" vowel.
+  ///
+  /// Pure function of [input] so cache keys stay deterministic. Non-number
+  /// text returns unchanged (`isPlain: true`), preserving existing cache.
+  ({String text, String? previousText, bool stable, bool isPlain})
+      _primeJapanese(String input) {
+    final core = input.trim().replaceAll(RegExp(r'[。、．，.\s]+$'), '');
+    final idx = _jaNumberReadings.indexOf(core);
+    if (idx < 0) {
+      return (text: input, previousText: null, stable: false, isPlain: true);
+    }
+    // Katakana renders these short number words more crisply and
+    // deterministically than hiragana (ご→ゴ, ろく→ロク, さん→サン) while
+    // sounding identical to the spoken number.
+    final lead = <String>[
+      if (idx >= 2) _toKatakana(_jaNumberReadings[idx - 2]),
+      if (idx >= 1) _toKatakana(_jaNumberReadings[idx - 1]),
+    ];
+    return (
+      text: '${_toKatakana(core)}。',
+      previousText: lead.isEmpty ? null : '${lead.join('、')}、',
+      stable: true,
+      isPlain: false,
+    );
+  }
+
+  /// Converts hiragana to katakana (U+3041–U+3096 → U+30A1–U+30F6).
+  String _toKatakana(String hiragana) {
+    final buf = StringBuffer();
+    for (final rune in hiragana.runes) {
+      buf.writeCharCode(
+        (rune >= 0x3041 && rune <= 0x3096) ? rune + 0x60 : rune,
+      );
+    }
+    return buf.toString();
+  }
+
   String _resolveVoiceId(String? overrideVoiceId) {
     final trimmed = overrideVoiceId?.trim() ?? '';
     if (trimmed.isNotEmpty) return trimmed;
@@ -226,7 +324,11 @@ class ElevenLabsTtsService {
     String? voiceId,
   }) {
     final resolvedVoiceId = _resolveVoiceId(voiceId);
-    return '$text|$resolvedVoiceId';
+    final primed = _primeJapanese(text);
+    final base = '${primed.text}|$resolvedVoiceId';
+    return primed.isPlain
+        ? base
+        : '$base|ctx:${primed.previousText ?? ''}|stable';
   }
 
   void dispose() {

--- a/lib/services/jlc_tts.dart
+++ b/lib/services/jlc_tts.dart
@@ -11,10 +11,28 @@ class JlcTts {
   JlcTts({String? elevenLabsVoiceId})
       : _fallback = FlutterTts(),
         _elevenLabsVoiceId = elevenLabsVoiceId?.trim() {
+    _configureFallbackAudio();
     if (_useElevenLabs) {
       unawaited(ElevenLabsTtsService.instance.prewarm());
       _prefetchCommonPackOnce();
     }
+  }
+
+  /// Routes device-TTS playback to the loud speaker (not the earpiece) on iOS,
+  /// mirroring the ElevenLabs path. Best-effort; no-op on Android/web.
+  void _configureFallbackAudio() {
+    unawaited(() async {
+      try {
+        await _fallback.setVolume(1.0);
+        if (!kIsWeb && defaultTargetPlatform == TargetPlatform.iOS) {
+          await _fallback.setIosAudioCategory(
+            IosTextToSpeechAudioCategory.playback,
+            const [IosTextToSpeechAudioCategoryOptions.mixWithOthers],
+            IosTextToSpeechAudioMode.defaultMode,
+          );
+        }
+      } catch (_) {}
+    }());
   }
 
   final FlutterTts _fallback;
@@ -137,6 +155,7 @@ class JlcTts {
   }
 
   Future<void> setVolume(double volume) async {
+    await ElevenLabsTtsService.instance.setVolume(volume);
     if (!_useElevenLabs) await _fallback.setVolume(volume);
   }
 


### PR DESCRIPTION
Audio (elevenlabs_tts_service.dart, jlc_tts.dart):
- Force playback onto the loudspeaker via an explicit AudioContext (playback category). audioplayers defaults to playAndRecord which, with the mic/STT session, routed audio to the quiet earpiece. Re-asserted before every clip and pinned to full volume.
- Route JlcTts.setVolume to the ElevenLabs player (was a no-op) and give the device-TTS fallback the same loud iOS playback route.

Pronunciation (elevenlabs_tts_service.dart):
- Prime isolated number readings (1-10) with counting context via previous_text (not spoken) + calm settings (style 0, stability 0.65) so short words like さん stop drifting to せん.
- Render number readings as katakana (さん→サン, ご→ゴ, ろく→ロク) for crisper, deterministic output. Number clips re-cache automatically.

UI (n5_hero_number1_lesson_screen.dart):
- Recolor সাজাও (Order) game accent teal→royal blue (#2563EB) to match the active tab; rename _teal→_accent.