### PR TITLE
Use granular MediaQuery accessors to cut needless rebuilds

### DIFF
--- a/lib/screens/hiragana_games.dart
+++ b/lib/screens/hiragana_games.dart
@@ -194,7 +194,7 @@ class _FlashcardDrillState extends State<FlashcardDrillScreen>
 
   @override
   Widget build(BuildContext context) {
-    final screenW = MediaQuery.of(context).size.width;
+    final screenW = MediaQuery.sizeOf(context).width;
     final cardSide = screenW * 0.72;
 
     return Scaffold(

--- a/lib/screens/n5_numbers_lesson2_screen.dart
+++ b/lib/screens/n5_numbers_lesson2_screen.dart
@@ -681,7 +681,7 @@ class _FallingNumbersGameState extends State<_FallingNumbersGame>
                             if (!_started) return const SizedBox.shrink();
                             final t = _fall.value;
                             final top = (t * 0.78) *
-                                (MediaQuery.of(context).size.height * 0.45);
+                                (MediaQuery.sizeOf(context).height * 0.45);
                             return Positioned(
                               top: 20 + top,
                               left: 0,

--- a/lib/screens/nihongo_trial_game_screen.dart
+++ b/lib/screens/nihongo_trial_game_screen.dart
@@ -814,8 +814,8 @@ class _TrialCompleteDialog extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final mq = MediaQuery.of(context);
-    final maxW = math.min(340.0, mq.size.width - 32);
+    final size = MediaQuery.sizeOf(context);
+    final maxW = math.min(340.0, size.width - 32);
 
     void onSignUp() {
       Get.dialog(
@@ -942,8 +942,8 @@ class _SubscribeUpsellDialog extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final mq = MediaQuery.of(context);
-    final maxW = math.min(380.0, mq.size.width - 28);
+    final size = MediaQuery.sizeOf(context);
+    final maxW = math.min(380.0, size.width - 28);
 
     return Dialog(
       backgroundColor: Colors.transparent,
@@ -1017,8 +1017,8 @@ class _SignupFormImageDialog extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final mq = MediaQuery.of(context);
-    final maxW = math.min(380.0, mq.size.width - 24);
+    final size = MediaQuery.sizeOf(context);
+    final maxW = math.min(380.0, size.width - 24);
 
     return Dialog(
       backgroundColor: Colors.transparent,

--- a/lib/screens/sign_up_screen.dart
+++ b/lib/screens/sign_up_screen.dart
@@ -180,10 +180,10 @@ class _SignUpScreenState extends State<SignUpScreen>
 
   @override
   Widget build(BuildContext context) {
-    final mq = MediaQuery.of(context);
-    final topPad = mq.padding.top;
-    final bottomPad = mq.padding.bottom;
-    final screenH = mq.size.height;
+    final padding = MediaQuery.paddingOf(context);
+    final topPad = padding.top;
+    final bottomPad = padding.bottom;
+    final screenH = MediaQuery.sizeOf(context).height;
 
     return Scaffold(
       backgroundColor: _sky,

--- a/lib/screens/splash_screen.dart
+++ b/lib/screens/splash_screen.dart
@@ -171,7 +171,7 @@ class _SplashScreenState extends State<SplashScreen>
 
   @override
   Widget build(BuildContext context) {
-    final screenH = MediaQuery.of(context).size.height;
+    final screenH = MediaQuery.sizeOf(context).height;
     final double logoTravelY = (screenH / 2) - 56;
 
     return Scaffold(


### PR DESCRIPTION
## What changed

Replaced `MediaQuery.of(context)` with the property-scoped accessors in 5 screens (7 spots) that only read screen size or padding:

| File | Change |
|---|---|
| `nihongo_trial_game_screen.dart` | 3× `MediaQuery.of(context)` → `MediaQuery.sizeOf(context)` |
| `sign_up_screen.dart` | split into `MediaQuery.paddingOf` + `MediaQuery.sizeOf` |
| `n5_numbers_lesson2_screen.dart` | → `MediaQuery.sizeOf(context).height` |
| `hiragana_games.dart` | → `MediaQuery.sizeOf(context).width` |
| `splash_screen.dart` | → `MediaQuery.sizeOf(context).height` |

## Why

`MediaQuery.of(context)` subscribes a widget to the **entire** `MediaQueryData`, so it rebuilds on *any* change — including keyboard show/hide (`viewInsets`) — even when the widget only uses `size` or `padding`. The granular accessors (`sizeOf`, `paddingOf`) rebuild only when that specific property changes.

Highest impact on the text-input screens (trial-game dialogs, sign-up), where the keyboard toggles frequently and was triggering full rebuilds for nothing.

## Reviewer notes

- **No behavior change** — same values, just narrower rebuild subscriptions.
- `main.dart`'s `MediaQuery(...)` override is intentionally **left as-is**: it reads `size`/`padding`/`textScaler` together to build the fixed web phone frame, so it legitimately needs the full data.
- Two files already used the granular form (`forum_post_detail_screen.dart`, `app_settings_menu.dart`) and were untouched.
- Base is `feat/flutter-upgrade` so this diff is scoped to just the MediaQuery change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)